### PR TITLE
ci: update GitHub Actions to latest versions

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,7 @@
 # This file is used by Copier to track the template version
 # and enable template updates in generated projects
 
-_commit: f9c71f007d4853a7d6d0026e7e32f60796e4851c
+_commit: 4b6aefd63aada5a339dc336bbec4a27796c7331a
 _src_path: gh:stateful-y/python-package-copier
 author_email: gtauzin@stateful-y.io
 author_name: Guillaume Tauzin

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -45,7 +45,7 @@ jobs:
           echo "version=${TAG_NAME}" >> $GITHUB_OUTPUT
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
 
       - name: Run pre-commit on generated CHANGELOG
         run: |
@@ -53,7 +53,7 @@ jobs:
           uvx pre-commit run --files CHANGELOG.md || true
 
       - name: Create Pull Request for CHANGELOG
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.CHANGELOG_AUTOMATION_TOKEN }}
           add-paths: |
@@ -101,7 +101,7 @@ jobs:
         run: uvx twine check dist/*
 
       - name: Store the distribution packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ env.dists-artifact-name }}
           path: dist/*

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Create issue on failure
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const title = '🔴 Nightly build failed';

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -13,7 +13,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Validate PR title follows conventional commit format
-        uses: amannn/action-semantic-pull-request@v5
+        uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -111,9 +111,9 @@ jobs:
       - name: Find release tag
         id: find_tag
         run: |
-          # Extract version from PR title (e.g., "chore(release): update CHANGELOG.md for v0.2.0")
+          # Extract version from PR title (e.g., "chore(release): update CHANGELOG.md for v0.2.0" or "v0.1.0-alpha.1")
           PR_TITLE="${{ github.event.pull_request.title }}"
-          VERSION=$(echo "$PR_TITLE" | grep -oP 'v[0-9]+\.[0-9]+\.[0-9]+' || echo "")
+          VERSION=$(echo "$PR_TITLE" | grep -oP 'v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+(\.[0-9]+)?)?' || echo "")
 
           if [ -z "$VERSION" ]; then
             echo "No version found in PR title"


### PR DESCRIPTION
## Description

Updates GitHub Actions workflows to use the latest versions of actions and adds support for pre-release version handling.

## Type of Change

- [x] CI/CD update

## Motivation and Context

Keeps GitHub Actions up-to-date with the latest versions to benefit from bug fixes, security updates, and new features. Also adds support for pre-release versions in the publish workflow.

## Changes

- Update astral-sh/setup-uv from v5 to v7
- Update peter-evans/create-pull-request from v7 to v8
- Update actions/upload-artifact from v4 to v6
- Update actions/github-script from v7 to v8
- Update amannn/action-semantic-pull-request from v5 to v6
- Update publish-release workflow to handle pre-release versions (e.g., v0.1.0-alpha.1)
- Update copier template version to 4b6aefd

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just format` to format my code
- [x] All workflow files are valid YAML
- [x] Changes have been tested locally where applicable