### PR TITLE
refactor: enforce `_estimator_name` as constructor keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ class PolynomialWrapper(BaseClassWrapper, RegressorMixin):
 
 # Use with sklearn tools
 wrapper = PolynomialWrapper(
-    estimator_class=PolynomialRegressor,
+    regressor=PolynomialRegressor,
     degree=2,
     learning_rate=0.01
 )

--- a/docs/pages/getting-started.md
+++ b/docs/pages/getting-started.md
@@ -112,7 +112,7 @@ y = 2 + 3*X.ravel() + 0.5*X.ravel()**2 + np.random.randn(100)
 
 # Create wrapped estimator
 wrapper = PolynomialWrapper(
-    estimator_class=PolynomialRegressor,
+    regressor=PolynomialRegressor,
     degree=2,
     learning_rate=0.01,
     n_iterations=1000

--- a/examples/first_wrapper.py
+++ b/examples/first_wrapper.py
@@ -171,7 +171,7 @@ def generate_regression_data(n_samples=300, n_features=2, noise=20, test_size=0.
 def _(PolyWrapper, PolynomialRegressor, degree_slider, lr_slider, np):
     # Create wrapper with slider values
     wrapper = PolyWrapper(
-        estimator_class=PolynomialRegressor,
+        poly_regressor=PolynomialRegressor,
         degree=degree_slider.value,
         learning_rate=lr_slider.value,
     )

--- a/examples/fit_context.py
+++ b/examples/fit_context.py
@@ -161,12 +161,12 @@ def _(DecoratorWrapper, ManualWrapper, SimpleModel, np):
     y = np.array([10, 20, 30])
 
     # Manual approach
-    manual = ManualWrapper(estimator_class=SimpleModel, alpha=2.0)
+    manual = ManualWrapper(model=SimpleModel, alpha=2.0)
     manual.fit(X, y)
     manual_pred = manual.predict(X)
 
     # Decorator approach
-    decorator = DecoratorWrapper(estimator_class=SimpleModel, alpha=2.0)
+    decorator = DecoratorWrapper(model=SimpleModel, alpha=2.0)
     decorator.fit(X, y)
     decorator_pred = decorator.predict(X)
     return X, decorator_pred, manual_pred, y
@@ -250,7 +250,7 @@ def _(BaseClassWrapper, np, _fit_context):
 
 @app.cell
 def _(IncrementalModel, IncrementalWrapper, X, y):
-    incr = IncrementalWrapper(estimator_class=IncrementalModel)
+    incr = IncrementalWrapper(model=IncrementalModel)
 
     # Multiple partial_fit calls
     incr.partial_fit(X[:2], y[:2])

--- a/examples/grid_search.py
+++ b/examples/grid_search.py
@@ -128,7 +128,7 @@ def _(GridSearchCV, KNNClassifier, KNNWrapper):
     }
 
     # Create wrapper and run grid search
-    wrapper = KNNWrapper(estimator_class=KNNClassifier)
+    wrapper = KNNWrapper(knn=KNNClassifier)
     grid_search = GridSearchCV(wrapper, param_grid, cv=3, scoring="accuracy", return_train_score=True)
     grid_search.fit(X_train, y_train)
 

--- a/examples/nested_wrappers.py
+++ b/examples/nested_wrappers.py
@@ -113,12 +113,12 @@ def _(BaseClassWrapper, BaseRegressor, BaseWrapper, EnsembleRegressor):
             return self.instance_.compute_blend(X)
 
     # Create two inner estimators with different scales
-    inner1 = BaseWrapper(estimator_class=BaseRegressor, scale=0.8)
-    inner2 = BaseWrapper(estimator_class=BaseRegressor, scale=1.2)
+    inner1 = BaseWrapper(regressor=BaseRegressor, scale=0.8)
+    inner2 = BaseWrapper(regressor=BaseRegressor, scale=1.2)
 
     # Create ensemble with nested estimators
     ensemble = EnsembleWrapper(
-        estimator_class=EnsembleRegressor,
+        ensemble=EnsembleRegressor,
         estimator1=inner1,
         estimator2=inner2,
         blend=0.5
@@ -183,9 +183,9 @@ def _(create_slider, mo):
 def _(BaseRegressor, BaseWrapper, EnsembleRegressor, EnsembleWrapper, blend_slider, scale1_slider, scale2_slider):
     # Create ensemble with slider-controlled parameters using nested syntax
     ensemble_interactive = EnsembleWrapper(
-        estimator_class=EnsembleRegressor,
-        estimator1=BaseWrapper(estimator_class=BaseRegressor, scale=scale1_slider.value),
-        estimator2=BaseWrapper(estimator_class=BaseRegressor, scale=scale2_slider.value),
+        ensemble=EnsembleRegressor,
+        estimator1=BaseWrapper(regressor=BaseRegressor, scale=scale1_slider.value),
+        estimator2=BaseWrapper(regressor=BaseRegressor, scale=scale2_slider.value),
         blend=blend_slider.value
     )
 

--- a/examples/parameter_interface.py
+++ b/examples/parameter_interface.py
@@ -125,7 +125,7 @@ def generate_regression_data(n_samples=300, n_features=2, noise=20, test_size=0.
 def _(ConfigurableRegressor, ConfigurableWrapper, alpha_slider, beta_slider, generate_regression_data, np):
     # Create wrapper with slider values
     est = ConfigurableWrapper(
-        estimator_class=ConfigurableRegressor,
+        model=ConfigurableRegressor,
         alpha=alpha_slider.value,
         beta=beta_slider.value,
     )
@@ -247,7 +247,7 @@ def _(mo):
 @app.cell
 def _(ConfigurableWrapper, ConfigurableRegressor, X_test, X_train, y_train):
     # Create, update, and fit
-    est2 = ConfigurableWrapper(estimator_class=ConfigurableRegressor, alpha=1.0, beta=0.0)
+    est2 = ConfigurableWrapper(model=ConfigurableRegressor, alpha=1.0, beta=0.0)
 
     # set_params() returns self for method chaining
     est2.set_params(alpha=2.5, beta=-1.0)

--- a/examples/serialization.py
+++ b/examples/serialization.py
@@ -97,7 +97,7 @@ def __(SimpleRegressor, SimpleWrapper, generate_regression_data):
     # Train and fit
     X_train, X_test, y_train, y_test = generate_regression_data()
 
-    estimator = SimpleWrapper(estimator_class=SimpleRegressor, multiplier=2.0)
+    estimator = SimpleWrapper(regressor=SimpleRegressor, multiplier=2.0)
     estimator.fit(X_train, y_train)
 
     original_predictions = estimator.predict(X_test)
@@ -150,7 +150,7 @@ def __(SimpleRegressor, SimpleWrapper, StandardScaler, Pipeline, X_test, X_train
     # Create and fit pipeline
     pipeline = Pipeline([
         ("scaler", StandardScaler()),
-        ("regressor", SimpleWrapper(estimator_class=SimpleRegressor, multiplier=1.5))
+        ("regressor", SimpleWrapper(regressor=SimpleRegressor, multiplier=1.5))
     ])
 
     pipeline.fit(X_train, y_train)
@@ -201,7 +201,7 @@ def __(mo):
 def __(SimpleRegressor, SimpleWrapper, GridSearchCV, X_test, X_train, y_train):
     # Run grid search
     grid = GridSearchCV(
-        SimpleWrapper(estimator_class=SimpleRegressor),
+        SimpleWrapper(regressor=SimpleRegressor),
         param_grid={"multiplier": [0.5, 1.0, 1.5, 2.0]},
         cv=3,
         scoring="neg_mean_squared_error"

--- a/examples/validation.py
+++ b/examples/validation.py
@@ -80,7 +80,7 @@ def create_error_demo(operation, error_title, explanation):
 @app.cell
 def _(SimpleModel, SimpleWrapper):
     def invalid_param_operation():
-        wrapper = SimpleWrapper(estimator_class=SimpleModel, valid_param=1.0)
+        wrapper = SimpleWrapper(model=SimpleModel, valid_param=1.0)
         wrapper.set_params(nonexistent_param=999)
     return (invalid_param_operation,)
 
@@ -125,7 +125,7 @@ def _():
 @app.cell
 def _(NotSklearnClass, StrictWrapper):
     def wrong_base_operation():
-        StrictWrapper(estimator_class=NotSklearnClass)
+        StrictWrapper(estimator=NotSklearnClass)
     return (wrong_base_operation,)
 
 
@@ -163,7 +163,7 @@ def _():
 def _(ModelWithRequired, SimpleWrapper, np):
     def missing_required_operation():
         # Create wrapper without required_param
-        wrapper = SimpleWrapper(estimator_class=ModelWithRequired, optional_param=20)
+        wrapper = SimpleWrapper(model=ModelWithRequired, optional_param=20)
         # Error happens during instantiate()
         wrapper.fit(np.array([[1, 2]]), np.array([1]))
     return (missing_required_operation,)
@@ -193,7 +193,7 @@ def _(mo):
 @app.cell
 def _(SimpleModel, SimpleWrapper):
     def reserved_delimiter_operation():
-        SimpleWrapper(estimator_class=SimpleModel, param__invalid=1.0)
+        SimpleWrapper(model=SimpleModel, param__invalid=1.0)
     return (reserved_delimiter_operation,)
 
 
@@ -298,7 +298,7 @@ def _(EnsembleModel, EnsembleWrapper, SimpleRegressor):
     def non_wrapper_constraint_operation():
         # This fails: SimpleRegressor is not a BaseClassWrapper
         raw_estimator = SimpleRegressor(scale=1.0)
-        EnsembleWrapper(estimator_class=EnsembleModel, inner_estimator=raw_estimator)
+        EnsembleWrapper(ensemble=EnsembleModel, inner_estimator=raw_estimator)
     return (non_wrapper_constraint_operation,)
 
 
@@ -324,8 +324,8 @@ def _(mo):
 @app.cell
 def _(EnsembleModel, EnsembleWrapper, RegressorWrapper, SimpleRegressor, np):
     # This works: inner_estimator is a BaseClassWrapper
-    inner_wrapper = RegressorWrapper(estimator_class=SimpleRegressor, scale=1.5)
-    valid_ensemble = EnsembleWrapper(estimator_class=EnsembleModel, inner_estimator=inner_wrapper)
+    inner_wrapper = RegressorWrapper(regressor=SimpleRegressor, scale=1.5)
+    valid_ensemble = EnsembleWrapper(ensemble=EnsembleModel, inner_estimator=inner_wrapper)
 
     # Test it
     X_ensemble = np.array([[1], [2], [3]])

--- a/src/sklearn_wrap/base.py
+++ b/src/sklearn_wrap/base.py
@@ -124,10 +124,7 @@ class BaseClassWrapper(BaseEstimator, metaclass=abc.ABCMeta):
             if default_cls is not None:
                 params[name] = default_cls
             else:
-                raise TypeError(
-                    f"{self.__class__.__name__}.__init__() missing required "
-                    f"keyword argument: '{name}'"
-                )
+                raise TypeError(f"{self.__class__.__name__}.__init__() missing required keyword argument: '{name}'")
         estimator_class = params.pop(name)
 
         self.estimator_class = self._validate_estimator_class(estimator_class)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,6 +91,14 @@ class MissingBaseClassWrapper(BaseClassWrapper):
     _estimator_name = "simple"
 
 
+class DefaultClassWrapper(BaseClassWrapper):
+    """Wrapper with a default estimator class."""
+
+    _estimator_name = "simple"
+    _estimator_base_class = BaseTestClass
+    _estimator_default_class = NoRequiredParams
+
+
 # ============================================================================
 # Constants
 # ============================================================================

--- a/tests/test_base_params.py
+++ b/tests/test_base_params.py
@@ -21,14 +21,14 @@ from .conftest import BaseTestClass, NoRequiredParams, SimpleEstimator, SimpleWr
 
 def test_get_params_returns_dict():
     """Test that get_params returns a dictionary."""
-    wrapper = SimpleWrapper(estimator_class=SimpleEstimator, required_param=5)
+    wrapper = SimpleWrapper(simple=SimpleEstimator, required_param=5)
     params = wrapper.get_params()
     assert isinstance(params, dict)
 
 
 def test_get_params_includes_estimator_name():
     """Test that get_params includes the estimator name key."""
-    wrapper = SimpleWrapper(estimator_class=SimpleEstimator, required_param=5)
+    wrapper = SimpleWrapper(simple=SimpleEstimator, required_param=5)
     params = wrapper.get_params()
     assert "simple" in params
     assert params["simple"] == SimpleEstimator
@@ -37,7 +37,7 @@ def test_get_params_includes_estimator_name():
 def test_get_params_includes_all_params():
     """Test that get_params includes all constructor parameters."""
     wrapper = SimpleWrapper(
-        estimator_class=SimpleEstimator,
+        simple=SimpleEstimator,
         required_param=5,
         optional_param=20,
         another_optional="test",
@@ -51,7 +51,7 @@ def test_get_params_includes_all_params():
 
 def test_get_params_includes_defaults():
     """Test that get_params includes default parameter values."""
-    wrapper = SimpleWrapper(estimator_class=SimpleEstimator, required_param=5)
+    wrapper = SimpleWrapper(simple=SimpleEstimator, required_param=5)
     params = wrapper.get_params()
 
     assert params["optional_param"] == 10
@@ -60,7 +60,7 @@ def test_get_params_includes_defaults():
 
 def test_get_params_with_deep_parameter():
     """Test that get_params accepts deep parameter."""
-    wrapper = SimpleWrapper(estimator_class=SimpleEstimator, required_param=5)
+    wrapper = SimpleWrapper(simple=SimpleEstimator, required_param=5)
     params_deep = wrapper.get_params(deep=True)
     params_shallow = wrapper.get_params(deep=False)
 
@@ -71,7 +71,7 @@ def test_get_params_with_deep_parameter():
 
 def test_get_params_deep_with_nested_estimator():
     """Test get_params with deep=True and nested estimators."""
-    inner_wrapper = SimpleWrapper(estimator_class=SimpleEstimator, required_param=1)
+    inner_wrapper = SimpleWrapper(simple=SimpleEstimator, required_param=1)
 
     class ClassWithNestedEstimator(BaseTestClass):
         def __init__(self, nested=None, simple_param=5):
@@ -79,7 +79,7 @@ def test_get_params_deep_with_nested_estimator():
             self.simple_param = simple_param
 
     wrapper = SimpleWrapper(
-        estimator_class=ClassWithNestedEstimator,
+        simple=ClassWithNestedEstimator,
         nested=inner_wrapper,
         simple_param=10,
     )
@@ -107,7 +107,7 @@ def test_get_params_deep_with_non_wrapper_nested():
             return {"value": self.value}
 
     # Manually set a param to this object
-    wrapper = SimpleWrapper(estimator_class=SimpleEstimator, required_param=5)
+    wrapper = SimpleWrapper(simple=SimpleEstimator, required_param=5)
     wrapper.params["custom_obj"] = NonWrapperWithGetParams(value=100)
 
     # Get params with deep=True - should include nested params
@@ -123,7 +123,7 @@ def test_get_params_deep_with_non_wrapper_nested():
 
 def test_set_params_updates_params():
     """Test that set_params updates parameters correctly."""
-    wrapper = SimpleWrapper(estimator_class=SimpleEstimator, required_param=5)
+    wrapper = SimpleWrapper(simple=SimpleEstimator, required_param=5)
     wrapper.set_params(optional_param=30)
 
     assert wrapper.params["optional_param"] == 30
@@ -131,7 +131,7 @@ def test_set_params_updates_params():
 
 def test_set_params_returns_self():
     """Test that set_params returns self for chaining."""
-    wrapper = SimpleWrapper(estimator_class=SimpleEstimator, required_param=5)
+    wrapper = SimpleWrapper(simple=SimpleEstimator, required_param=5)
     result = wrapper.set_params(optional_param=30)
 
     assert result is wrapper
@@ -139,7 +139,7 @@ def test_set_params_returns_self():
 
 def test_set_params_multiple_params():
     """Test setting multiple parameters at once."""
-    wrapper = SimpleWrapper(estimator_class=SimpleEstimator, required_param=5)
+    wrapper = SimpleWrapper(simple=SimpleEstimator, required_param=5)
     wrapper.set_params(optional_param=25, another_optional="new")
 
     assert wrapper.params["optional_param"] == 25
@@ -148,7 +148,7 @@ def test_set_params_multiple_params():
 
 def test_set_params_empty():
     """Test set_params with no arguments."""
-    wrapper = SimpleWrapper(estimator_class=SimpleEstimator, required_param=5)
+    wrapper = SimpleWrapper(simple=SimpleEstimator, required_param=5)
     original_class = wrapper.estimator_class
 
     wrapper.set_params()
@@ -162,7 +162,7 @@ def test_set_params_empty():
 
 def test_set_params_then_instantiate():
     """Test changing params and then instantiating."""
-    wrapper = SimpleWrapper(estimator_class=SimpleEstimator, required_param=5)
+    wrapper = SimpleWrapper(simple=SimpleEstimator, required_param=5)
     wrapper.set_params(required_param=5, optional_param=77)
     wrapper.instantiate()
 
@@ -172,7 +172,7 @@ def test_set_params_then_instantiate():
 
 def test_set_params_changes_estimator_class():
     """Test that set_params raises error when trying to change the estimator class."""
-    wrapper = SimpleWrapper(estimator_class=SimpleEstimator, required_param=5)
+    wrapper = SimpleWrapper(simple=SimpleEstimator, required_param=5)
 
     with pytest.raises(ValueError, match="Cannot change estimator class via set_params"):
         wrapper.set_params(simple=NoRequiredParams)
@@ -180,23 +180,23 @@ def test_set_params_changes_estimator_class():
 
 def test_set_params_validates_new_params():
     """Test that set_params validates new parameters."""
-    wrapper = SimpleWrapper(estimator_class=SimpleEstimator, required_param=5)
+    wrapper = SimpleWrapper(simple=SimpleEstimator, required_param=5)
 
     with pytest.raises(ValueError, match="'invalid_param' is not a valid parameter for class 'SimpleEstimator'"):
         wrapper.set_params(invalid_param=100)
 
 
 def test_set_params_with_estimator_class_key():
-    """Test that set_params rejects estimator_class parameter."""
-    wrapper = SimpleWrapper(estimator_class=SimpleEstimator, required_param=5)
+    """Test that set_params rejects unknown 'estimator_class' parameter."""
+    wrapper = SimpleWrapper(simple=SimpleEstimator, required_param=5)
 
-    with pytest.raises(ValueError, match="Cannot change estimator class via set_params"):
+    with pytest.raises(ValueError, match="'estimator_class' is not a valid parameter for class 'SimpleEstimator'"):
         wrapper.set_params(estimator_class=NoRequiredParams)
 
 
 def test_set_params_with_non_type_estimator_value():
     """Test that set_params raises error when trying to set estimator name."""
-    wrapper = SimpleWrapper(estimator_class=SimpleEstimator, required_param=5)
+    wrapper = SimpleWrapper(simple=SimpleEstimator, required_param=5)
 
     # Passing any value for estimator name should raise an error
     with pytest.raises(ValueError, match="Cannot change estimator class via set_params"):
@@ -205,7 +205,7 @@ def test_set_params_with_non_type_estimator_value():
 
 def test_set_params_invalid_param_after_validation():
     """Test error when param doesn't exist after validation."""
-    wrapper = SimpleWrapper(estimator_class=SimpleEstimator, required_param=5)
+    wrapper = SimpleWrapper(simple=SimpleEstimator, required_param=5)
 
     with pytest.raises(
         ValueError, match="'totally_invalid_param' is not a valid parameter for class 'SimpleEstimator'"
@@ -220,14 +220,14 @@ def test_set_params_invalid_param_after_validation():
 
 def test_set_params_nested_basic():
     """Test basic nested parameter setting with __ syntax."""
-    inner_wrapper = SimpleWrapper(estimator_class=SimpleEstimator, required_param=1, optional_param=10)
+    inner_wrapper = SimpleWrapper(simple=SimpleEstimator, required_param=1, optional_param=10)
 
     class ClassWithNested(BaseTestClass):
         def __init__(self, estimator=None, other_param=5):
             self.estimator = estimator
             self.other_param = other_param
 
-    outer_wrapper = SimpleWrapper(estimator_class=ClassWithNested, estimator=inner_wrapper, other_param=10)
+    outer_wrapper = SimpleWrapper(simple=ClassWithNested, estimator=inner_wrapper, other_param=10)
 
     # Set nested parameter using __ syntax
     outer_wrapper.set_params(estimator__optional_param=100)
@@ -240,14 +240,14 @@ def test_set_params_nested_basic():
 def test_set_params_nested_multiple_levels():
     """Test multi-level nested parameter setting."""
     # Create a 3-level nested structure
-    level1 = SimpleWrapper(estimator_class=SimpleEstimator, required_param=1, optional_param=10)
+    level1 = SimpleWrapper(simple=SimpleEstimator, required_param=1, optional_param=10)
 
     class ClassWithNested(BaseTestClass):
         def __init__(self, inner=None):
             self.inner = inner
 
-    level2 = SimpleWrapper(estimator_class=ClassWithNested, inner=level1)
-    level3 = SimpleWrapper(estimator_class=ClassWithNested, inner=level2)
+    level2 = SimpleWrapper(simple=ClassWithNested, inner=level1)
+    level3 = SimpleWrapper(simple=ClassWithNested, inner=level2)
 
     # Set deeply nested parameter
     level3.set_params(inner__inner__optional_param=999)
@@ -258,14 +258,14 @@ def test_set_params_nested_multiple_levels():
 
 def test_set_params_nested_and_simple_mixed():
     """Test setting both nested and simple parameters together."""
-    inner = SimpleWrapper(estimator_class=SimpleEstimator, required_param=1, optional_param=10)
+    inner = SimpleWrapper(simple=SimpleEstimator, required_param=1, optional_param=10)
 
     class ClassWithNested(BaseTestClass):
         def __init__(self, estimator=None, other_param=5):
             self.estimator = estimator
             self.other_param = other_param
 
-    outer = SimpleWrapper(estimator_class=ClassWithNested, estimator=inner, other_param=10)
+    outer = SimpleWrapper(simple=ClassWithNested, estimator=inner, other_param=10)
 
     # Set both nested and simple params in one call
     outer.set_params(estimator__optional_param=200, other_param=20)
@@ -276,14 +276,14 @@ def test_set_params_nested_and_simple_mixed():
 
 def test_set_params_nested_estimator_object():
     """Test set_params with an estimator object that has get_params/set_params."""
-    inner_wrapper = SimpleWrapper(estimator_class=SimpleEstimator, required_param=1, optional_param=10)
+    inner_wrapper = SimpleWrapper(simple=SimpleEstimator, required_param=1, optional_param=10)
 
     class ClassWithEstimatorParam(BaseTestClass):
         def __init__(self, estimator=None, other_param=5):
             self.estimator = estimator
             self.other_param = other_param
 
-    outer_wrapper = SimpleWrapper(estimator_class=ClassWithEstimatorParam, estimator=inner_wrapper, other_param=10)
+    outer_wrapper = SimpleWrapper(simple=ClassWithEstimatorParam, estimator=inner_wrapper, other_param=10)
 
     # Update regular params (not nested with __)
     outer_wrapper.set_params(other_param=20)
@@ -300,7 +300,7 @@ def test_set_params_nested_without_set_params_method():
         def __init__(self, scalar_param=5):
             self.scalar_param = scalar_param
 
-    wrapper = SimpleWrapper(estimator_class=ClassWithScalar, scalar_param=10)
+    wrapper = SimpleWrapper(simple=ClassWithScalar, scalar_param=10)
 
     # Try to set nested parameter on a scalar value
     with pytest.raises(AttributeError, match="does not have a set_params method"):
@@ -309,7 +309,7 @@ def test_set_params_nested_without_set_params_method():
 
 def test_set_params_nested_invalid_base_key():
     """Test error when trying to set nested param on non-existent base param."""
-    wrapper = SimpleWrapper(estimator_class=SimpleEstimator, required_param=5)
+    wrapper = SimpleWrapper(simple=SimpleEstimator, required_param=5)
 
     # Try to set a nested parameter on a base param that doesn't exist
     with pytest.raises(ValueError, match="Invalid parameter 'nested' for estimator"):
@@ -328,13 +328,13 @@ def test_parameter_constraints_wrapper_base_class():
         _parameter_constraints = {"estimator": [{"wrapper_base_class": BaseTestClass}]}
 
     # Valid: wrapper with correct base class
-    inner = SimpleWrapper(estimator_class=SimpleEstimator, required_param=1)
+    inner = SimpleWrapper(simple=SimpleEstimator, required_param=1)
 
     class ClassWithNested(BaseTestClass):
         def __init__(self, estimator=None):
             self.estimator = estimator
 
-    outer = SpecializedWrapper(estimator_class=ClassWithNested, estimator=inner)
+    outer = SpecializedWrapper(simple=ClassWithNested, estimator=inner)
     # This should work - no error
     outer.set_params(estimator__optional_param=100)
 
@@ -351,7 +351,7 @@ def test_parameter_constraints_not_wrapper():
 
     # Try to set a non-wrapper value when wrapper is required
     with pytest.raises(TypeError, match="must be a BaseClassWrapper instance"):
-        SpecializedWrapper(estimator_class=ClassWithNested, estimator="not a wrapper")
+        SpecializedWrapper(simple=ClassWithNested, estimator="not a wrapper")
 
 
 def test_parameter_constraints_wrong_base_class():
@@ -372,7 +372,7 @@ def test_parameter_constraints_wrong_base_class():
         _parameter_constraints = {"estimator": [{"wrapper_base_class": BaseTestClass}]}
 
     # Create a wrapper with wrong base class
-    wrong_inner = OtherWrapper(estimator_class=OtherDummyClass, param=1)
+    wrong_inner = OtherWrapper(other=OtherDummyClass, param=1)
 
     class ClassWithNested(BaseTestClass):
         def __init__(self, estimator=None):
@@ -380,7 +380,7 @@ def test_parameter_constraints_wrong_base_class():
 
     # Should raise error about wrong base class
     with pytest.raises(ValueError, match="must wrap an estimator class derived from"):
-        SpecializedWrapper(estimator_class=ClassWithNested, estimator=wrong_inner)
+        SpecializedWrapper(simple=ClassWithNested, estimator=wrong_inner)
 
 
 def test_parameter_constraints_empty():
@@ -390,7 +390,7 @@ def test_parameter_constraints_empty():
         _parameter_constraints = {}
 
     # Should work fine with any parameter
-    wrapper = WrapperNoConstraints(estimator_class=SimpleEstimator, required_param=5)
+    wrapper = WrapperNoConstraints(simple=SimpleEstimator, required_param=5)
     assert wrapper.params["required_param"] == 5
 
 
@@ -401,7 +401,7 @@ def test_parameter_constraints_non_matching():
         _parameter_constraints = {"nonexistent_param": [{"wrapper_base_class": BaseTestClass}]}
 
     # Should still work - constraints only apply if the parameter exists
-    wrapper = WrapperWithNonMatchingConstraint(estimator_class=SimpleEstimator, required_param=5)
+    wrapper = WrapperWithNonMatchingConstraint(simple=SimpleEstimator, required_param=5)
     assert wrapper.params["required_param"] == 5
 
 
@@ -419,12 +419,12 @@ def test_parameter_names_cannot_contain_double_underscore():
 
     # Should raise error when trying to create wrapper with param containing __
     with pytest.raises(ValueError, match="cannot contain '__'"):
-        SimpleWrapper(estimator_class=ClassWithInvalidParam, invalid__param=10)
+        SimpleWrapper(simple=ClassWithInvalidParam, invalid__param=10)
 
 
 def test_validate_double_underscore_directly():
     """Test direct validation of params dict with __ in name."""
-    wrapper = SimpleWrapper(estimator_class=SimpleEstimator, required_param=5)
+    wrapper = SimpleWrapper(simple=SimpleEstimator, required_param=5)
 
     # Direct test: try to validate params dict with __ in name
     with pytest.raises(ValueError, match="cannot contain '__'"):
@@ -439,7 +439,7 @@ def test_validate_double_underscore_directly():
 def test_get_set_params_roundtrip():
     """Test that get_params/set_params roundtrip works correctly."""
     wrapper = SimpleWrapper(
-        estimator_class=SimpleEstimator,
+        simple=SimpleEstimator,
         required_param=5,
         optional_param=20,
         another_optional="test",
@@ -448,9 +448,8 @@ def test_get_set_params_roundtrip():
     # Get all params
     params = wrapper.get_params()
 
-    # Remove estimator class parameters (can't be changed via set_params)
+    # Remove estimator class parameter (can't be changed via set_params)
     params.pop("simple", None)
-    params.pop("estimator_class", None)
 
     # Set them back
     wrapper.set_params(**params)
@@ -463,21 +462,20 @@ def test_get_set_params_roundtrip():
 
 def test_get_set_params_roundtrip_with_nested():
     """Test that get_params/set_params roundtrip works with nested estimators."""
-    inner = SimpleWrapper(estimator_class=SimpleEstimator, required_param=1, optional_param=10)
+    inner = SimpleWrapper(simple=SimpleEstimator, required_param=1, optional_param=10)
 
     class ClassWithNested(BaseTestClass):
         def __init__(self, estimator=None, other_param=5):
             self.estimator = estimator
             self.other_param = other_param
 
-    outer = SimpleWrapper(estimator_class=ClassWithNested, estimator=inner, other_param=10)
+    outer = SimpleWrapper(simple=ClassWithNested, estimator=inner, other_param=10)
 
     # Get all params (including nested)
     all_params = outer.get_params(deep=True)
 
-    # Remove the estimator class params (can't be changed via set_params)
+    # Remove the estimator class param (can't be changed via set_params)
     all_params.pop("simple", None)
-    all_params.pop("estimator_class", None)
 
     # Set them back - should work without error
     outer.set_params(**all_params)
@@ -489,7 +487,7 @@ def test_get_set_params_roundtrip_with_nested():
 
 def test_sklearn_get_set_params_compatibility():
     """Test that get_params/set_params work with sklearn's parameter handling."""
-    wrapper = SimpleWrapper(estimator_class=SimpleEstimator, required_param=5)
+    wrapper = SimpleWrapper(simple=SimpleEstimator, required_param=5)
 
     # Get params
     params = wrapper.get_params()
@@ -497,9 +495,8 @@ def test_sklearn_get_set_params_compatibility():
     # Modify params
     params["optional_param"] = 100
 
-    # Remove estimator class parameters before setting
+    # Remove estimator class parameter before setting
     params.pop("simple", None)
-    params.pop("estimator_class", None)
 
     # Set params back
     wrapper.set_params(**params)
@@ -522,7 +519,7 @@ def test_validate_estimator_params_skip_nested_validation():
         def expose_validation(self, params, validate_nested=True):
             return self._validate_estimator_params(params, validate_nested=validate_nested)
 
-    wrapper = TestWrapper(estimator_class=SimpleEstimator, required_param=5)
+    wrapper = TestWrapper(test=SimpleEstimator, required_param=5)
 
     # Call with validate_nested=False - should return params as-is
     params = {"param1": "value1", "param2": "value2"}
@@ -550,7 +547,7 @@ def test_parameter_constraint_with_non_wrapper_class():
 
     # This should raise TypeError because we're passing a class, not a BaseClassWrapper instance
     with pytest.raises(TypeError, match="must be a BaseClassWrapper instance"):
-        StrictWrapper(estimator_class=OuterClass, inner=InnerClass)
+        StrictWrapper(strict=OuterClass, inner=InnerClass)
 
 
 def test_parameter_constraint_with_non_dict_constraint():
@@ -567,7 +564,7 @@ def test_parameter_constraint_with_non_dict_constraint():
         _parameter_constraints = {"param": ["not_a_dict"]}
 
     # Should work fine - non-dict constraints are ignored by _validate_nested_wrapper_param
-    wrapper = TestWrapper(estimator_class=ClassWithParam, param="value")
+    wrapper = TestWrapper(test=ClassWithParam, param="value")
     assert wrapper.params["param"] == "value"
 
 
@@ -584,7 +581,7 @@ def test_set_params_with_none_value_and_constraints():
             self.optional = optional
 
     # Create wrapper with None value
-    wrapper = TestWrapper(estimator_class=OuterClass, optional=None)
+    wrapper = TestWrapper(test=OuterClass, optional=None)
 
     # Set to None explicitly - should skip validation
     wrapper.set_params(optional=None)

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -31,10 +31,10 @@ class TestDeepNesting:
             def __init__(self, inner=None):
                 self.inner = inner
 
-        level1 = SimpleWrapper(estimator_class=SimpleEstimator, required_param=1)
-        level2 = SimpleWrapper(estimator_class=ClassWithNested, inner=level1)
-        level3 = SimpleWrapper(estimator_class=ClassWithNested, inner=level2)
-        level4 = SimpleWrapper(estimator_class=ClassWithNested, inner=level3)
+        level1 = SimpleWrapper(simple=SimpleEstimator, required_param=1)
+        level2 = SimpleWrapper(simple=ClassWithNested, inner=level1)
+        level3 = SimpleWrapper(simple=ClassWithNested, inner=level2)
+        level4 = SimpleWrapper(simple=ClassWithNested, inner=level3)
 
         # Get deep params
         params = level4.get_params(deep=True)
@@ -56,11 +56,11 @@ class TestDeepNesting:
             def __init__(self, inner=None):
                 self.inner = inner
 
-        level1 = SimpleWrapper(estimator_class=SimpleEstimator, required_param=1, optional_param=10)
-        level2 = SimpleWrapper(estimator_class=ClassWithNested, inner=level1)
-        level3 = SimpleWrapper(estimator_class=ClassWithNested, inner=level2)
-        level4 = SimpleWrapper(estimator_class=ClassWithNested, inner=level3)
-        level5 = SimpleWrapper(estimator_class=ClassWithNested, inner=level4)
+        level1 = SimpleWrapper(simple=SimpleEstimator, required_param=1, optional_param=10)
+        level2 = SimpleWrapper(simple=ClassWithNested, inner=level1)
+        level3 = SimpleWrapper(simple=ClassWithNested, inner=level2)
+        level4 = SimpleWrapper(simple=ClassWithNested, inner=level3)
+        level5 = SimpleWrapper(simple=ClassWithNested, inner=level4)
 
         # Set deeply nested parameter
         level5.set_params(inner__inner__inner__inner__optional_param=555)
@@ -87,7 +87,7 @@ class TestSlotsClasses:
                 self.param1 = param1
                 self.param2 = param2
 
-        wrapper = SimpleWrapper(estimator_class=SlottedClass, param1=5, param2=20)
+        wrapper = SimpleWrapper(simple=SlottedClass, param1=5, param2=20)
 
         # Should work normally
         assert wrapper.params["param1"] == 5
@@ -110,7 +110,7 @@ class TestSlotsClasses:
                     self.__dict__["dynamic_param"] = dynamic_param
 
         # Note: This class has __slots__ but also allows __dict__ for additional attrs
-        wrapper = SimpleWrapper(estimator_class=MixedSlottedClass, fixed_param=10, dynamic_param="test")
+        wrapper = SimpleWrapper(simple=MixedSlottedClass, fixed_param=10, dynamic_param="test")
 
         wrapper.instantiate()
         assert wrapper.instance_.fixed_param == 10
@@ -140,7 +140,7 @@ class TestPropertyBasedParams:
             def value(self, val):
                 self._value = val * 2  # Property transforms value
 
-        wrapper = SimpleWrapper(estimator_class=PropertyClass, value=5)
+        wrapper = SimpleWrapper(simple=PropertyClass, value=5)
 
         wrapper.instantiate()
         # Value should be transformed by property setter
@@ -157,7 +157,7 @@ class TestPropertyBasedParams:
             def computed_value(self):
                 return self.base_value * 2
 
-        wrapper = SimpleWrapper(estimator_class=ReadOnlyPropertyClass, base_value=15)
+        wrapper = SimpleWrapper(simple=ReadOnlyPropertyClass, base_value=15)
 
         wrapper.instantiate()
         assert wrapper.instance_.base_value == 15
@@ -182,7 +182,7 @@ class TestDynamicClasses:
         # Create class dynamically
         DynamicClass = type("DynamicClass", (BaseTestClass,), {"__init__": __init__})
 
-        wrapper = SimpleWrapper(estimator_class=DynamicClass, param1=10, param2=30)
+        wrapper = SimpleWrapper(simple=DynamicClass, param1=10, param2=30)
 
         assert wrapper.params["param1"] == 10
         assert wrapper.params["param2"] == 30
@@ -204,7 +204,7 @@ class TestDynamicClasses:
 
         BaseClass.custom_method = custom_method
 
-        wrapper = SimpleWrapper(estimator_class=BaseClass, value=15)
+        wrapper = SimpleWrapper(simple=BaseClass, value=15)
         wrapper.instantiate()
 
         # Dynamically added method should work
@@ -223,7 +223,7 @@ class TestParamDictMutationSafety:
         """Test that modifying external dict doesn't affect wrapper params."""
         params_dict = {"required_param": 5, "optional_param": 20}
 
-        wrapper = SimpleWrapper(estimator_class=SimpleEstimator, **params_dict)
+        wrapper = SimpleWrapper(simple=SimpleEstimator, **params_dict)
 
         # Modify external dict
         params_dict["optional_param"] = 999
@@ -235,7 +235,7 @@ class TestParamDictMutationSafety:
 
     def test_get_params_dict_mutation_doesnt_affect_wrapper(self):
         """Test that modifying returned params dict doesn't affect wrapper."""
-        wrapper = SimpleWrapper(estimator_class=SimpleEstimator, required_param=5, optional_param=20)
+        wrapper = SimpleWrapper(simple=SimpleEstimator, required_param=5, optional_param=20)
 
         # Get params
         params = wrapper.get_params()
@@ -248,7 +248,7 @@ class TestParamDictMutationSafety:
 
     def test_params_attribute_mutation_safety(self):
         """Test that wrapper.params modifications are handled correctly."""
-        wrapper = SimpleWrapper(estimator_class=SimpleEstimator, required_param=5, optional_param=20)
+        wrapper = SimpleWrapper(simple=SimpleEstimator, required_param=5, optional_param=20)
 
         # Direct modification of params dict (not recommended but testing safety)
         wrapper.params["optional_param"] = 999
@@ -277,7 +277,7 @@ class TestCallableDefaults:
                 self.value = value
                 self.factory = factory if factory is not None else (lambda: [])
 
-        wrapper = SimpleWrapper(estimator_class=ClassWithCallableDefault, value=15)
+        wrapper = SimpleWrapper(simple=ClassWithCallableDefault, value=15)
 
         wrapper.instantiate()
         assert wrapper.instance_.value == 15
@@ -294,7 +294,7 @@ class TestCallableDefaults:
                 self.value = value
                 self.func = func
 
-        wrapper = SimpleWrapper(estimator_class=ClassWithFunctionDefault, value=20)
+        wrapper = SimpleWrapper(simple=ClassWithFunctionDefault, value=20)
 
         wrapper.instantiate()
         assert wrapper.instance_.value == 20
@@ -321,7 +321,7 @@ class TestAbstractBaseClasses:
                 self.value = value
 
         # Creating wrapper should work (abstract check happens at instantiation)
-        wrapper = SimpleWrapper(estimator_class=AbstractClass, value=15)
+        wrapper = SimpleWrapper(simple=AbstractClass, value=15)
 
         # But instantiating should fail
         with pytest.raises(TypeError, match="Can't instantiate abstract class"):
@@ -342,7 +342,7 @@ class TestAbstractBaseClasses:
             def abstract_method(self):
                 return self.value * 2
 
-        wrapper = SimpleWrapper(estimator_class=ConcreteClass, value=15)
+        wrapper = SimpleWrapper(simple=ConcreteClass, value=15)
 
         wrapper.instantiate()
         assert wrapper.instance_.value == 15
@@ -368,7 +368,7 @@ class TestMultipleInheritance:
             def __init__(self, value=10):
                 self.value = value
 
-        wrapper = SimpleWrapper(estimator_class=MultipleInheritanceClass, value=25)
+        wrapper = SimpleWrapper(simple=MultipleInheritanceClass, value=25)
 
         wrapper.instantiate()
         assert wrapper.instance_.value == 25
@@ -389,7 +389,7 @@ class TestMultipleInheritance:
             def __init__(self, value=10):
                 self.value = value
 
-        wrapper = SimpleWrapper(estimator_class=ComplexMRO, value=30)
+        wrapper = SimpleWrapper(simple=ComplexMRO, value=30)
 
         wrapper.instantiate()
         # Should use Base1's method (first in MRO)
@@ -412,7 +412,7 @@ class TestSpecialParameterNames:
                 self.required = required
                 self.kwargs = kwargs
 
-        wrapper = SimpleWrapper(estimator_class=ClassWithKwargs, required=5, extra1="value1", extra2="value2")
+        wrapper = SimpleWrapper(simple=ClassWithKwargs, required=5, extra1="value1", extra2="value2")
 
         wrapper.instantiate()
         assert wrapper.instance_.required == 5
@@ -428,7 +428,7 @@ class TestSpecialParameterNames:
 
         # Note: *args in constructor signature can't be easily filled from kwargs
         # This tests that the wrapper handles the signature correctly
-        wrapper = SimpleWrapper(estimator_class=ClassWithArgs)
+        wrapper = SimpleWrapper(simple=ClassWithArgs)
 
         # Should instantiate with no args
         wrapper.instantiate()
@@ -462,9 +462,9 @@ class TestEdgeCaseCombinations:
             def __init__(self, inner=None):
                 self.inner = inner
 
-        level1 = SimpleWrapper(estimator_class=PropertyClass, value=5)
-        level2 = SimpleWrapper(estimator_class=ClassWithNested, inner=level1)
-        level3 = SimpleWrapper(estimator_class=ClassWithNested, inner=level2)
+        level1 = SimpleWrapper(simple=PropertyClass, value=5)
+        level2 = SimpleWrapper(simple=ClassWithNested, inner=level1)
+        level3 = SimpleWrapper(simple=ClassWithNested, inner=level2)
 
         # Set nested parameter
         level3.set_params(inner__inner__value=100)
@@ -485,8 +485,8 @@ class TestEdgeCaseCombinations:
             def __init__(self, inner=None):
                 self.inner = inner
 
-        inner = SimpleWrapper(estimator_class=SlottedClass, value=50)
-        outer = SimpleWrapper(estimator_class=ClassWithNested, inner=inner)
+        inner = SimpleWrapper(simple=SlottedClass, value=50)
+        outer = SimpleWrapper(simple=ClassWithNested, inner=inner)
 
         # Get nested params
         params = outer.get_params(deep=True)

--- a/tests/test_fit_context.py
+++ b/tests/test_fit_context.py
@@ -24,8 +24,8 @@ def test_fit_context_decorator_basic():
     """Test the _fit_context decorator functionality."""
 
     class FittableWrapper(SimpleWrapper):
-        def __init__(self, estimator_class, **params):
-            super().__init__(estimator_class, **params)
+        def __init__(self, simple, **params):
+            super().__init__(simple=simple, **params)
             self.fit_called = False
 
         @_fit_context(prefer_skip_nested_validation=True)
@@ -33,7 +33,7 @@ def test_fit_context_decorator_basic():
             self.fit_called = True
             return self
 
-    wrapper = FittableWrapper(estimator_class=SimpleEstimator, required_param=5)
+    wrapper = FittableWrapper(simple=SimpleEstimator, required_param=5)
     X = [[1, 2], [3, 4]]
     y = [0, 1]
 
@@ -53,7 +53,7 @@ def test_fit_context_sets_fitted_flag():
         def fit(self, X, y=None):
             return self
 
-    wrapper = FittableWrapper(estimator_class=SimpleEstimator, required_param=5)
+    wrapper = FittableWrapper(simple=SimpleEstimator, required_param=5)
     X = [[1, 2], [3, 4]]
 
     # Before fit
@@ -73,8 +73,8 @@ def test_fit_context_decorator_partial_fit():
     """Test _fit_context decorator with partial_fit when already fitted."""
 
     class PartialFittableWrapper(SimpleWrapper):
-        def __init__(self, estimator_class, **params):
-            super().__init__(estimator_class, **params)
+        def __init__(self, simple, **params):
+            super().__init__(simple=simple, **params)
             self.partial_fit_count = 0
             self.instantiate_count = 0
 
@@ -87,7 +87,7 @@ def test_fit_context_decorator_partial_fit():
             self.partial_fit_count += 1
             return self
 
-    wrapper = PartialFittableWrapper(estimator_class=SimpleEstimator, required_param=5)
+    wrapper = PartialFittableWrapper(simple=SimpleEstimator, required_param=5)
     X = [[1, 2], [3, 4]]
     y = [0, 1]
 
@@ -110,8 +110,8 @@ def test_fit_context_partial_fit_reinstantiates_when_not_fitted():
     """Test that partial_fit reinstantiates if estimator is not fitted."""
 
     class PartialFittableWrapper(SimpleWrapper):
-        def __init__(self, estimator_class, **params):
-            super().__init__(estimator_class, **params)
+        def __init__(self, simple, **params):
+            super().__init__(simple=simple, **params)
             self.instantiate_count = 0
 
         def instantiate(self):
@@ -122,7 +122,7 @@ def test_fit_context_partial_fit_reinstantiates_when_not_fitted():
         def partial_fit(self, X, y=None):
             return self
 
-    wrapper = PartialFittableWrapper(estimator_class=SimpleEstimator, required_param=5)
+    wrapper = PartialFittableWrapper(simple=SimpleEstimator, required_param=5)
     X = [[1, 2], [3, 4]]
 
     # First call - should instantiate
@@ -170,8 +170,8 @@ def test_fit_context_decorator_with_skip_validation_config():
     """Test _fit_context decorator with global skip_parameter_validation config."""
 
     class FittableWrapper(SimpleWrapper):
-        def __init__(self, estimator_class, **params):
-            super().__init__(estimator_class, **params)
+        def __init__(self, simple, **params):
+            super().__init__(simple=simple, **params)
             self.fit_called = False
             self.validate_params_called = False
 
@@ -184,7 +184,7 @@ def test_fit_context_decorator_with_skip_validation_config():
             self.fit_called = True
             return self
 
-    wrapper = FittableWrapper(estimator_class=SimpleEstimator, required_param=5)
+    wrapper = FittableWrapper(simple=SimpleEstimator, required_param=5)
     X = [[1, 2], [3, 4]]
     y = [0, 1]
 
@@ -204,7 +204,7 @@ def test_fit_context_prefer_skip_nested_validation():
         def fit(self, X, y=None):
             return self
 
-    wrapper = FittableWrapper(estimator_class=SimpleEstimator, required_param=5)
+    wrapper = FittableWrapper(simple=SimpleEstimator, required_param=5)
     X = [[1, 2], [3, 4]]
 
     # Should work with prefer_skip_nested_validation=True
@@ -220,7 +220,7 @@ def test_fit_context_without_prefer_skip_nested_validation():
         def fit(self, X, y=None):
             return self
 
-    wrapper = FittableWrapper(estimator_class=SimpleEstimator, required_param=5)
+    wrapper = FittableWrapper(simple=SimpleEstimator, required_param=5)
     X = [[1, 2], [3, 4]]
 
     # Should still work
@@ -241,7 +241,7 @@ def test_fit_context_with_exception():
         def fit(self, X, y=None):
             raise ValueError("Intentional error")
 
-    wrapper = FittableWrapper(estimator_class=SimpleEstimator, required_param=5)
+    wrapper = FittableWrapper(simple=SimpleEstimator, required_param=5)
     X = [[1, 2], [3, 4]]
 
     # Fit raises exception
@@ -256,8 +256,8 @@ def test_fit_context_multiple_fits():
     """Test calling fit multiple times with _fit_context."""
 
     class FittableWrapper(SimpleWrapper):
-        def __init__(self, estimator_class, **params):
-            super().__init__(estimator_class, **params)
+        def __init__(self, simple, **params):
+            super().__init__(simple=simple, **params)
             self.fit_count = 0
 
         @_fit_context(prefer_skip_nested_validation=True)
@@ -265,7 +265,7 @@ def test_fit_context_multiple_fits():
             self.fit_count += 1
             return self
 
-    wrapper = FittableWrapper(estimator_class=SimpleEstimator, required_param=5)
+    wrapper = FittableWrapper(simple=SimpleEstimator, required_param=5)
     X = [[1, 2], [3, 4]]
 
     # First fit
@@ -292,7 +292,7 @@ def test_fit_context_validates_estimator_class():
             return self
 
     # Create wrapper with valid class
-    wrapper = FittableWrapper(estimator_class=SimpleEstimator, required_param=5)
+    wrapper = FittableWrapper(simple=SimpleEstimator, required_param=5)
 
     # Manually change to invalid class (bypass __init__ validation)
     wrapper.estimator_class = NotBaseClass

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -118,7 +118,7 @@ class TestPipelineIntegration:
         """Test that wrapper works as a step in Pipeline."""
         X, y = make_regression(n_samples=100, n_features=10, random_state=42)
 
-        wrapper = RegressorWrapper(estimator_class=SimpleRegressorClass, alpha=1.0)
+        wrapper = RegressorWrapper(regressor=SimpleRegressorClass, alpha=1.0)
 
         pipeline = Pipeline([("scaler", StandardScaler()), ("regressor", wrapper)])
 
@@ -133,7 +133,7 @@ class TestPipelineIntegration:
         """Test setting nested parameters in Pipeline."""
         X, y = make_regression(n_samples=100, n_features=10, random_state=42)
 
-        wrapper = RegressorWrapper(estimator_class=SimpleRegressorClass, alpha=1.0)
+        wrapper = RegressorWrapper(regressor=SimpleRegressorClass, alpha=1.0)
         pipeline = Pipeline([("scaler", StandardScaler()), ("regressor", wrapper)])
 
         # Set nested parameter
@@ -159,7 +159,7 @@ class TestGridSearchCVIntegration:
         """Test GridSearchCV with wrapped estimator."""
         X, y = make_regression(n_samples=100, n_features=10, random_state=42)
 
-        wrapper = RegressorWrapper(estimator_class=SimpleRegressorClass, alpha=1.0)
+        wrapper = RegressorWrapper(regressor=SimpleRegressorClass, alpha=1.0)
 
         param_grid = {"alpha": [0.5, 1.0, 2.0]}
 
@@ -175,7 +175,7 @@ class TestGridSearchCVIntegration:
         """Test GridSearchCV with wrapper in Pipeline."""
         X, y = make_regression(n_samples=100, n_features=10, random_state=42)
 
-        wrapper = RegressorWrapper(estimator_class=SimpleRegressorClass, alpha=1.0)
+        wrapper = RegressorWrapper(regressor=SimpleRegressorClass, alpha=1.0)
         pipeline = Pipeline([("scaler", StandardScaler()), ("regressor", wrapper)])
 
         param_grid = {"regressor__alpha": [0.5, 1.0, 2.0]}
@@ -189,7 +189,7 @@ class TestGridSearchCVIntegration:
         """Test that GridSearchCV preserves the best estimator correctly."""
         X, y = make_regression(n_samples=100, n_features=10, random_state=42)
 
-        wrapper = RegressorWrapper(estimator_class=SimpleRegressorClass, alpha=1.0)
+        wrapper = RegressorWrapper(regressor=SimpleRegressorClass, alpha=1.0)
 
         param_grid = {"alpha": [0.5, 1.0, 2.0, 5.0]}
 
@@ -214,7 +214,7 @@ class TestCrossValScoreIntegration:
         """Test cross_val_score with wrapped estimator."""
         X, y = make_regression(n_samples=100, n_features=10, random_state=42)
 
-        wrapper = RegressorWrapper(estimator_class=SimpleRegressorClass, alpha=1.0)
+        wrapper = RegressorWrapper(regressor=SimpleRegressorClass, alpha=1.0)
 
         scores = cross_val_score(wrapper, X, y, cv=3)
 
@@ -226,7 +226,7 @@ class TestCrossValScoreIntegration:
         """Test cross_val_score with wrapper in Pipeline."""
         X, y = make_regression(n_samples=100, n_features=10, random_state=42)
 
-        wrapper = RegressorWrapper(estimator_class=SimpleRegressorClass, alpha=1.0)
+        wrapper = RegressorWrapper(regressor=SimpleRegressorClass, alpha=1.0)
         pipeline = Pipeline([("scaler", StandardScaler()), ("regressor", wrapper)])
 
         scores = cross_val_score(pipeline, X, y, cv=3)
@@ -249,8 +249,8 @@ class TestEnsembleIntegration:
         X, y = make_regression(n_samples=100, n_features=10, random_state=42)
 
         # Create wrapped estimators
-        wrapper1 = RegressorWrapper(estimator_class=SimpleRegressorClass, alpha=0.5)
-        wrapper2 = RegressorWrapper(estimator_class=SimpleRegressorClass, alpha=2.0)
+        wrapper1 = RegressorWrapper(regressor=SimpleRegressorClass, alpha=0.5)
+        wrapper2 = RegressorWrapper(regressor=SimpleRegressorClass, alpha=2.0)
 
         # Use sklearn's Ridge as final estimator
         stacking = StackingRegressor(estimators=[("w1", wrapper1), ("w2", wrapper2)], final_estimator=Ridge())
@@ -265,8 +265,8 @@ class TestEnsembleIntegration:
         X, y = make_classification(n_samples=100, n_features=10, random_state=42)
 
         # Create wrapped estimators
-        wrapper1 = ClassifierWrapper(estimator_class=SimpleClassifierClass, threshold=0.3)
-        wrapper2 = ClassifierWrapper(estimator_class=SimpleClassifierClass, threshold=0.7)
+        wrapper1 = ClassifierWrapper(classifier=SimpleClassifierClass, threshold=0.3)
+        wrapper2 = ClassifierWrapper(classifier=SimpleClassifierClass, threshold=0.7)
 
         # Use voting classifier
         voting = VotingClassifier(estimators=[("w1", wrapper1), ("w2", wrapper2)], voting="hard")
@@ -283,11 +283,11 @@ class TestEnsembleIntegration:
         # Create pipelines with wrappers
         pipe1 = Pipeline([
             ("scaler", StandardScaler()),
-            ("regressor", RegressorWrapper(estimator_class=SimpleRegressorClass, alpha=0.5)),
+            ("regressor", RegressorWrapper(regressor=SimpleRegressorClass, alpha=0.5)),
         ])
         pipe2 = Pipeline([
             ("scaler", StandardScaler()),
-            ("regressor", RegressorWrapper(estimator_class=SimpleRegressorClass, alpha=2.0)),
+            ("regressor", RegressorWrapper(regressor=SimpleRegressorClass, alpha=2.0)),
         ])
 
         stacking = StackingRegressor(estimators=[("p1", pipe1), ("p2", pipe2)], final_estimator=Ridge())
@@ -316,7 +316,7 @@ class TestRealWorldScenarios:
         y_train, _y_test = y[:80], y[80:]
 
         # Create pipeline
-        wrapper = RegressorWrapper(estimator_class=SimpleRegressorClass, alpha=1.0)
+        wrapper = RegressorWrapper(regressor=SimpleRegressorClass, alpha=1.0)
         pipeline = Pipeline([("scaler", StandardScaler()), ("regressor", wrapper)])
 
         # Grid search
@@ -336,7 +336,7 @@ class TestRealWorldScenarios:
         """Test nested cross-validation scenario."""
         X, y = make_regression(n_samples=100, n_features=10, random_state=42)
 
-        wrapper = RegressorWrapper(estimator_class=SimpleRegressorClass, alpha=1.0)
+        wrapper = RegressorWrapper(regressor=SimpleRegressorClass, alpha=1.0)
 
         param_grid = {"alpha": [0.5, 1.0, 2.0]}
         grid_search = GridSearchCV(wrapper, param_grid, cv=3)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -60,7 +60,7 @@ class TestPickleUnfitted:
 
     def test_pickle_unfitted_wrapper(self):
         """Test pickling and unpickling an unfitted wrapper."""
-        wrapper = SimpleWrapper(estimator_class=SimpleEstimator, required_param=5, optional_param=20)
+        wrapper = SimpleWrapper(simple=SimpleEstimator, required_param=5, optional_param=20)
 
         # Pickle
         pickled = pickle.dumps(wrapper)
@@ -76,7 +76,7 @@ class TestPickleUnfitted:
     def test_pickle_preserves_parameters(self):
         """Test that pickling preserves all parameters."""
         wrapper = SimpleWrapper(
-            estimator_class=SimpleEstimator,
+            simple=SimpleEstimator,
             required_param=42,
             optional_param=100,
             another_optional="custom",
@@ -90,7 +90,7 @@ class TestPickleUnfitted:
 
     def test_pickle_unfitted_can_be_instantiated(self):
         """Test that unpickled unfitted wrapper can be instantiated."""
-        wrapper = SimpleWrapper(estimator_class=SimpleEstimator, required_param=5)
+        wrapper = SimpleWrapper(simple=SimpleEstimator, required_param=5)
 
         unpickled = pickle.loads(pickle.dumps(wrapper))
 
@@ -110,7 +110,7 @@ class TestPickleFitted:
 
     def test_pickle_fitted_wrapper(self):
         """Test pickling and unpickling a fitted wrapper."""
-        wrapper = SerializableWrapper(estimator_class=SimpleEstimator, required_param=5)
+        wrapper = SerializableWrapper(serializable=SimpleEstimator, required_param=5)
 
         # Fit the wrapper
         X = np.array([[1, 2], [3, 4], [5, 6]])
@@ -133,7 +133,7 @@ class TestPickleFitted:
 
     def test_pickle_fitted_can_predict(self):
         """Test that unpickled fitted wrapper can predict."""
-        wrapper = SerializableWrapper(estimator_class=SimpleEstimator, required_param=5)
+        wrapper = SerializableWrapper(serializable=SimpleEstimator, required_param=5)
 
         # Fit
         X_train = np.array([[1, 2], [3, 4], [5, 6]])
@@ -151,7 +151,7 @@ class TestPickleFitted:
 
     def test_pickle_fitted_preserves_instance(self):
         """Test that pickling preserves the fitted instance."""
-        wrapper = SerializableWrapper(estimator_class=SimpleEstimator, required_param=5)
+        wrapper = SerializableWrapper(serializable=SimpleEstimator, required_param=5)
 
         X = np.array([[1, 2], [3, 4]])
         wrapper.fit(X)
@@ -177,8 +177,8 @@ class TestPickleNested:
 
     def test_pickle_nested_wrappers(self):
         """Test pickling wrapper with nested wrapper parameter."""
-        inner = SimpleWrapper(estimator_class=SimpleEstimator, required_param=10, optional_param=20)
-        outer = SimpleWrapper(estimator_class=ClassWithNested, estimator=inner, value=15)
+        inner = SimpleWrapper(simple=SimpleEstimator, required_param=10, optional_param=20)
+        outer = SimpleWrapper(simple=ClassWithNested, estimator=inner, value=15)
 
         # Pickle and unpickle
         unpickled = pickle.loads(pickle.dumps(outer))
@@ -191,9 +191,9 @@ class TestPickleNested:
 
     def test_pickle_deep_nested_wrappers(self):
         """Test pickling deeply nested wrapper structure (3 levels)."""
-        level1 = SimpleWrapper(estimator_class=SimpleEstimator, required_param=1)
-        level2 = SimpleWrapper(estimator_class=ClassWithInner, inner=level1)
-        level3 = SimpleWrapper(estimator_class=ClassWithInner, inner=level2)
+        level1 = SimpleWrapper(simple=SimpleEstimator, required_param=1)
+        level2 = SimpleWrapper(simple=ClassWithInner, inner=level1)
+        level3 = SimpleWrapper(simple=ClassWithInner, inner=level2)
 
         # Pickle and unpickle
         unpickled = pickle.loads(pickle.dumps(level3))
@@ -214,7 +214,7 @@ class TestJoblibPersistence:
 
     def test_joblib_save_load_unfitted(self):
         """Test joblib save and load with unfitted wrapper."""
-        wrapper = SimpleWrapper(estimator_class=SimpleEstimator, required_param=5, optional_param=20)
+        wrapper = SimpleWrapper(simple=SimpleEstimator, required_param=5, optional_param=20)
 
         with tempfile.TemporaryDirectory() as tmpdir:
             filepath = Path(tmpdir) / "wrapper.joblib"
@@ -232,7 +232,7 @@ class TestJoblibPersistence:
 
     def test_joblib_save_load_fitted(self):
         """Test joblib save and load with fitted wrapper."""
-        wrapper = SerializableWrapper(estimator_class=SimpleEstimator, required_param=5)
+        wrapper = SerializableWrapper(serializable=SimpleEstimator, required_param=5)
 
         # Fit
         X = np.array([[1, 2], [3, 4], [5, 6]])
@@ -260,8 +260,8 @@ class TestJoblibPersistence:
 
     def test_joblib_with_nested_wrappers(self):
         """Test joblib persistence with nested wrappers."""
-        inner = SimpleWrapper(estimator_class=SimpleEstimator, required_param=10)
-        outer = SimpleWrapper(estimator_class=ClassWithNested, estimator=inner, value=15)
+        inner = SimpleWrapper(simple=SimpleEstimator, required_param=10)
+        outer = SimpleWrapper(simple=ClassWithNested, estimator=inner, value=15)
 
         with tempfile.TemporaryDirectory() as tmpdir:
             filepath = Path(tmpdir) / "nested_wrapper.joblib"
@@ -279,7 +279,7 @@ class TestJoblibPersistence:
 
     def test_joblib_compression(self):
         """Test joblib save with compression."""
-        wrapper = SerializableWrapper(estimator_class=SimpleEstimator, required_param=5)
+        wrapper = SerializableWrapper(serializable=SimpleEstimator, required_param=5)
 
         # Fit to create more data
         X = np.array([[1, 2], [3, 4], [5, 6]] * 100)
@@ -310,7 +310,7 @@ class TestSerializationEdgeCases:
 
     def test_pickle_wrapper_with_none_params(self):
         """Test pickling wrapper with None parameter values."""
-        wrapper = SimpleWrapper(estimator_class=ClassWithOptional, param1=None, param2="value")
+        wrapper = SimpleWrapper(simple=ClassWithOptional, param1=None, param2="value")
 
         unpickled = pickle.loads(pickle.dumps(wrapper))
 
@@ -319,7 +319,7 @@ class TestSerializationEdgeCases:
 
     def test_pickle_wrapper_after_set_params(self):
         """Test pickling after modifying parameters with set_params."""
-        wrapper = SimpleWrapper(estimator_class=SimpleEstimator, required_param=5)
+        wrapper = SimpleWrapper(simple=SimpleEstimator, required_param=5)
 
         # Modify params
         wrapper.set_params(optional_param=50, another_optional="modified")
@@ -333,7 +333,7 @@ class TestSerializationEdgeCases:
 
     def test_roundtrip_multiple_times(self):
         """Test multiple pickle/unpickle cycles."""
-        wrapper = SimpleWrapper(estimator_class=SimpleEstimator, required_param=5)
+        wrapper = SimpleWrapper(simple=SimpleEstimator, required_param=5)
 
         # First cycle
         unpickled1 = pickle.loads(pickle.dumps(wrapper))


### PR DESCRIPTION
## Description

Replace the generic `estimator_class` positional parameter with a keyword argument named after `_estimator_name` (e.g. `regressor=`, `classifier=`). Add `_estimator_default_class` for wrappers with a fixed wrapped class.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Motivation and Context

`get_params(deep=False)` returned `estimator_class` as the key, but `sklearn.base.clone()` would then call `Subclass(estimator_class=...)` which fails when subclasses use a custom `__init__`. This forced users to patch `BaseClassWrapper` (e.g. the `_OptunaWrapper` workaround). By using `_estimator_name` as the constructor keyword, `get_params` and `clone()` are naturally aligned.

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just format` to format my code
- [x] I have run `just check` to verify type annotations
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings

## Additional Notes

155 tests passing, 100% code coverage.