### PR TITLE
chore: replace template placeholders with actual project values

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,7 @@
 # This file is used by Copier to track the template version
 # and enable template updates in generated projects
 
-_commit: 2058a3f03bbac40791fffe5e7452e01964e53290
+_commit: f63733734198662e0f6809f9ba7908855989064c
 _src_path: gh:stateful-y/python-package-copier
 author_email: gtauzin@stateful-y.io
 author_name: Guillaume Tauzin

--- a/.git-cliff.toml
+++ b/.git-cliff.toml
@@ -33,10 +33,10 @@ This **{{ release_type }} release** includes {{ commits | length }} commit{%- if
 
 ### {{ group | striptags | trim | upper_first }}
 {%- for commit in commits %}
-- {{ commit.message | upper_first }}{%- if commit.github.pr_number %} ([#{{ commit.github.pr_number }}](https://github.com/{{ github_username }}/{{ project_slug }}/pull/{{ commit.github.pr_number }})){%- endif %}{%- if commit.github.username %} by @{{ commit.github.username }}{%- endif %}
+- {{ commit.message | upper_first }}{%- if commit.remote.pr_number %} ([#{{ commit.remote.pr_number }}](https://github.com/stateful-y/sklearn-wrap/pull/{{ commit.remote.pr_number }})){%- endif %}{%- if commit.remote.username %} by @{{ commit.remote.username }}{%- endif %}
 {%- endfor %}
 {%- endfor %}
-{%- set new_contributors = commits | filter(attribute="github.username") | map(attribute="github.username") | unique %}
+{%- set new_contributors = commits | filter(attribute="remote.username") | map(attribute="remote.username") | unique %}
 {%- if new_contributors | length > 0 %}
 
 ### Contributors

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url: https://github.com/stateful-y/sklearn-wrap/discussions
     about: Please use GitHub Discussions for questions and general discussions
   - name: Documentation
-    url: https://stateful-y.github.io/sklearn-wrap/
+    url: https://sklearn-wrap.readthedocs.io/
     about: Check the documentation for guides and API references

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Question or Discussion
-    url: https://github.com/{{ github_username }}/{{ package_name }}/discussions
+    url: https://github.com/stateful-y/sklearn-wrap/discussions
     about: Please use GitHub Discussions for questions and general discussions
   - name: Documentation
-    url: https://{{ github_username }}.github.io/{{ package_name }}/
+    url: https://stateful-y.github.io/sklearn-wrap/
     about: Check the documentation for guides and API references

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -28,7 +28,7 @@ body:
       description: Show how you'd like to use this feature (optional)
       render: python
       placeholder: |
-        from {{ package_name }} import new_feature
+        from sklearn_wrap import new_feature
         result = new_feature()
 
   - type: textarea

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,43 @@
+# Contributor Covenant Code of Conduct
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at gtauzin@stateful-y.io. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 1.4, available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+For answers to common questions about this code of conduct, see https://www.contributor-covenant.org/faq


### PR DESCRIPTION
## Description

Replace template placeholders in configuration files with actual project values.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Other (please describe):

## Motivation and Context

Configuration files contained template placeholders (e.g., `{{ github_username }}`, `{{ package_name }}`) that needed to be replaced with actual values for proper functionality.

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just format` to format my code
- [x] I have run `just check` to verify type annotations
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings

## Additional Notes

Updated files:
- `.git-cliff.toml`: Replaced github template variables with remote and actual repo path
- `.github/ISSUE_TEMPLATE/config.yml`: Replaced placeholders with actual URLs
- `.github/ISSUE_TEMPLATE/feature_request.yml`: Replaced package_name placeholder