### PR TITLE
docs: export examples as both static HTML and interactive WASM

### DIFF
--- a/docs/pages/examples.md
+++ b/docs/pages/examples.md
@@ -4,19 +4,19 @@ Learn Sklearn-Wrap through focused, interactive examples. Each notebook demonstr
 
 ## Fundamentals
 
-### [first_wrapper.py](/examples/first_wrapper/)
+### A First Wrapper ([View](/examples/first_wrapper/) | [Editable](/examples/first_wrapper/edit/))
 
 **Creating Your First Sklearn-Compatible Wrapper**
 
 Start here to understand the fundamental wrapper pattern. This example walks through wrapping a custom polynomial regression algorithm that uses gradient descent. You'll learn the three essential components every wrapper needs: the `_estimator_name` and `_estimator_base_class` attributes, plus the `@_fit_context` decorator. By the end, you'll have a working wrapper that integrates seamlessly with Scikit-Learn's ecosystem.
 
-### [parameter_interface.py](/examples/parameter_interface/)
+### Parameter Interface ([View](/examples/parameter_interface/) | [Editable](/examples/parameter_interface/edit/))
 
 **Mastering the Parameter Interface**
 
 Dive deep into how `get_params()` and `set_params()` work under the hood. This example demonstrates why Scikit-Learn needs this interface for GridSearchCV and Pipeline, and shows exactly what happens when you change parameters on a fitted estimator. You'll see interactive demos of parameter inspection and modification, plus understand the distinction between wrapper parameters and wrapped class parameters. Essential for working with Scikit-Learn's hyperparameter tuning tools.
 
-### [validation.py](/examples/validation/)
+### Validation ([View](/examples/validation/) | [Editable](/examples/validation/edit/))
 
 **Error Patterns and Parameter Validation**
 
@@ -24,13 +24,13 @@ Learn to handle errors gracefully by exploring five common validation scenarios:
 
 ## Integration with Scikit-Learn
 
-### [grid_search.py](/examples/grid_search/)
+### Grid Search ([View](/examples/grid_search/) | [Editable](/examples/grid_search/edit/))
 
 **Hyperparameter Tuning with GridSearchCV**
 
 Apply what you've learned to real hyperparameter optimization. This example wraps a k-nearest neighbors classifier and uses GridSearchCV to find optimal `n_neighbors` and `weights` values through cross-validation. You'll see how Scikit-Learn's parameter interface enables automatic tuning without any special code in your wrapper. Includes interactive parameter exploration and visual comparison of grid search results versus default parameters.
 
-### [nested_wrappers.py](/examples/nested_wrappers/)
+### Nested Wrappers ([View](/examples/nested_wrappers/) | [Editable](/examples/nested_wrappers/edit/))
 
 **Controlling Nested Estimator Hierarchies**
 
@@ -38,19 +38,19 @@ Master Scikit-Learn's double-underscore syntax for nested parameters. This examp
 
 ## Advanced Topics
 
-### [xgboost_wrapper.py](/examples/xgboost_wrapper/)
+### XGBoost Wrapper ([View](/examples/xgboost_wrapper/) | [Editable](/examples/xgboost_wrapper/edit/))
 
 **Wrapping XGBoost's Booster API**
 
 Integrate third-party libraries by wrapping XGBoost's low-level training API. Unlike XGBoost's built-in Scikit-Learn wrappers (XGBRegressor/XGBClassifier), the Booster API offers finer control over the training process. This example shows how to handle library-specific quirks like DMatrix conversion and parameter formatting. Demonstrates that Sklearn-Wrap isn't just for custom code, it's equally valuable for bringing external libraries into Scikit-Learn's ecosystem.
 
-### [serialization.py](/examples/serialization/)
+### Serialization ([View](/examples/serialization/) | [Editable](/examples/serialization/edit/))
 
 **Persistence with Joblib**
 
 Save and load your wrapped estimators for production deployment. This example covers three serialization scenarios: standalone wrapped estimators, complete pipelines combining wrappers with Scikit-Learn transformers, and full GridSearchCV objects including all cross-validation results. You'll verify that deserialized objects maintain identical behavior to their originals, which is critical for reproducible ML workflows and model deployment.
 
-### [fit_context.py](/examples/fit_context/)
+### Fit Context ([View](/examples/fit_context/) | [Editable](/examples/fit_context/edit/))
 
 **Understanding the _fit_context Decorator**
 


### PR DESCRIPTION
## Description

Export example notebooks in both static HTML (read-only) and interactive html-wasm (editable in-browser). Static HTML is the default at `/examples/<name>/`, WASM editor lives at `/examples/<name>/edit/`.

## Type of Change

- [x] Documentation update

## Motivation and Context

Previously only html-wasm exports were available. Adding static HTML gives a faster-loading read-only view while keeping the interactive editor accessible via an "Editable" link.

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just format` to format my code
- [ ] I have run `just check` to verify type annotations
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings