### PR TITLE
chore: update copier template and align notebook examples with contributing guidelines

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,7 @@
 # This file is used by Copier to track the template version
 # and enable template updates in generated projects
 
-_commit: acbec10b5a0aa812c2f957053fa5cc67bbc05f9d
+_commit: 367c229274f328bf7e08d4f094731a000977494b
 _src_path: gh:stateful-y/python-package-copier
 author_email: gtauzin@stateful-y.io
 author_name: Guillaume Tauzin

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,7 @@
 # This file is used by Copier to track the template version
 # and enable template updates in generated projects
 
-_commit: 367c229274f328bf7e08d4f094731a000977494b
+_commit: 34af1eded43e8feca2f8d2a5b8f1eca86b359317
 _src_path: gh:stateful-y/python-package-copier
 author_email: gtauzin@stateful-y.io
 author_name: Guillaume Tauzin

--- a/docs/pages/contributing.md
+++ b/docs/pages/contributing.md
@@ -402,15 +402,13 @@ Create a new marimo notebook in `examples/<name>.py`:
 === "uv run"
 
 2. Develop your example in the marimo editor, following the standardized structure:
-   - **Overview**: Explain what readers will learn (flexible length)
-   - **Pyodide install cell**: Immediately after the overview, add a hidden cell that installs packages when running in the browser via pyodide (see template below)
    - **Numbered sections**: Main concepts as `## 1.`, `## 2.`, `## 3.`
    - **Key Takeaways**: Bullet points summarizing important lessons
    - **Next Steps**: Links to related notebooks for progression
    - Isolate utilities and markdown in separate cells
    - Use `hide_code=True` for infrastructure cells: `import marimo`, pyodide install, library imports, utilities, and markdown cells
 
-   **Pyodide install cell template** (place right after the overview cell):
+   **Pyodide install cell template** (place right after `import marimo as mo`):
 
    ```python
    @app.cell(hide_code=True)

--- a/docs/pages/contributing.md
+++ b/docs/pages/contributing.md
@@ -387,58 +387,131 @@ just --list
 
 ### Adding Examples
 
-All examples are interactive [marimo](https://marimo.io) notebooks that combine code, markdown, and visualizations. Follow these guidelines:
+All examples are interactive [marimo](https://marimo.io) notebooks that combine code, markdown, and visualizations.
 
-1. Create a new marimo notebook in `examples/<name>.py`:
+#### Creating a Notebook
 
-   === "just"
+Create a new marimo notebook in `examples/<name>.py`:
 
-       ```bash
-       just example <name>.py
-       ```
+=== "just"
 
-   === "uv run"
+    ```bash
+    just example <name>.py
+    ```
 
-       ```bash
-       uv run marimo new examples/<name>.py
-       ```
+=== "uv run"
 
-2. Develop your example in the marimo editor, ollowing the standardized structure:
+2. Develop your example in the marimo editor, following the standardized structure:
    - **Overview**: Explain what readers will learn (flexible length)
+   - **Pyodide install cell**: Immediately after the overview, add a hidden cell that installs packages when running in the browser via pyodide (see template below)
    - **Numbered sections**: Main concepts as `## 1.`, `## 2.`, `## 3.`
    - **Key Takeaways**: Bullet points summarizing important lessons
-   - **Next Steps**: Context for progression to related notebooks
-   - Use `hide_code=True` for utility functions (sliders, data generation, visualization)
+   - **Next Steps**: Links to related notebooks for progression
+   - Isolate utilities and markdown in separate cells
+   - Use `hide_code=True` for infrastructure cells: `import marimo`, pyodide install, library imports, utilities, and markdown cells
 
-3. Run the example test suite to verify it passes:
+   **Pyodide install cell template** (place right after the overview cell):
 
-   === "just"
+   ```python
+   @app.cell(hide_code=True)
+   async def _():
+       import sys
 
-       ```bash
-       just test-examples
-       ```
+       if "pyodide" in sys.modules:
+           import micropip
 
-   === "nox"
-
-       ```bash
-       uvx nox -s test_examples
-       ```
-
-   === "uv run"
-
-       ```bash
-       uv run pytest tests/test_examples.py -m example
-       ```
-
-4. Add a link to your example in `docs/pages/examples.md`:
-
-   ```markdown
-   - [Example Name](../examples/<name>/) - Brief description
+           await micropip.install(["scikit-learn"]) # List all packages needed to run the example
+       return
    ```
 
-5. The mkdocs hooks automatically exports notebooks to HTML during docs build
+   **`hide_code=True` guidance** — mark these cells as hidden:
 
-All notebooks in `examples/` are automatically discovered and tested by `test_examples.py` using pytest's parametrization feature, which runs them in parallel for fast validation.
+   | Cell type | Why hidden |
+   |-----------|-----------|
+   | `import marimo as mo` | Boilerplate, not instructive |
+   | Pyodide install | Infrastructure, not tutorial content |
+   | Library imports | Setup, readers focus on usage |
+   | Utilities | Not the lesson |
+   | Markdown cells | Purely structural |
+
+   Leave these cells **visible**:
+
+   | Cell type | Why visible |
+   |-----------|------------|
+   | Model construction / `MyEstimator(...)` | Core teaching content |
+   | `search.fit(...)` calls | Demonstrates usage |
+   | Results display | Shows output interpretation |
+
+#### Required Structure
+
+Every example notebook **must** follow this structure in order:
+
+1. **Title**: A top-level `# Title` heading describing the notebook topic
+2. **What You'll Learn**: A `## What You'll Learn` section with a bulleted list of concrete learning goals
+3. **Prerequisites**: A `## Prerequisites` section stating required prior knowledge (one-liner or short bullet list). For standalone dataset explorations, use "None -- this is a standalone dataset exploration."
+4. **Numbered sections**: Main content as `## 1. Section Name`, `## 2. Section Name`, etc.
+5. **Key Takeaways**: A `## Key Takeaways` section with bullet points summarizing important lessons learned
+6. **Next Steps**: A `## Next Steps` section with bullet points linking to related notebooks or documentation
+
+**Example intro cell**:
+
+```markdown
+# Reduction Forecasting with sklearn
+
+## What You'll Learn
+
+- How `PointReductionForecaster` tabularizes time series data using lag features
+- The difference between `target_transformer` and `feature_transformer` parameters
+- Tuning hyperparameters with `GridSearchCV`
+
+## Prerequisites
+
+Basic familiarity with sklearn's fit/predict API and time series concepts (trend, seasonality).
+```
+
+#### Marimo Cell Conventions
+
+- Use `hide_code=True` on all markdown cells, import cells, and utility/helper cells
+- Use `r"""..."""` (raw triple-quoted strings) for markdown cell content
+- The second cell (after `import marimo as mo`) must be the Pyodide/micropip guard for browser compatibility
+- Group all imports into a single hidden cell after the Pyodide guard
+
+#### Content Guidelines
+
+- **Markdown density**: Each numbered section should open with a descriptive markdown cell explaining the concept before any code cells. Consecutive code cells within the same section are acceptable when logically grouped.
+- **No emojis**: Do not use emojis anywhere in notebooks -- not in headings, content bullets, or concluding remarks.
+- **Key Takeaways format**: Use bold for key terms with plain descriptions (e.g., `- **Reduction forecasting** converts time series into tabular regression via lag features`)
+- **Next Steps format**: Use bold labels with brief descriptions (e.g., `- **Naive baselines**: See naive_forecasters.py to compare with simple benchmarks`)
+
+#### Testing and Documentation
+
+Run the example test suite to verify your notebook passes:
+
+=== "just"
+
+    ```bash
+    just test-examples
+    ```
+
+=== "nox"
+
+    ```bash
+    uvx nox -s test_examples
+    ```
+
+=== "uv run"
+
+    ```bash
+    uv run pytest tests/test_examples.py -m example
+    ```
+
+Add a link to your example in `docs/pages/examples.md`:
+
+```markdown
+- [Example Name](../examples/<name>/) - Brief description
+```
+
+The mkdocs hooks automatically export notebooks to HTML during docs build. All notebooks in `examples/` are automatically discovered and tested by `test_examples.py` using pytest's parametrization feature, which runs them in parallel for fast validation.
 
 ## Submitting Changes
 

--- a/docs/pages/user-guide.md
+++ b/docs/pages/user-guide.md
@@ -54,7 +54,7 @@ class MyWrapper(BaseClassWrapper):
 ```
 
 !!! example "Interactive Example"
-    See [**First Wrapper**](/examples/first_wrapper/) for an interactive demonstration of creating your first wrapper.
+    See **First Wrapper** ([View](/examples/first_wrapper/) | [Editable](/examples/first_wrapper/edit/)) for an interactive demonstration of creating your first wrapper.
 
 ### The instantiate() Method
 
@@ -99,7 +99,7 @@ def fit(self, X, y):
 ```
 
 !!! example "Interactive Example"
-    See [**Fit Context**](/examples/fit_context/) for an interactive demonstration of the `_fit_context` decorator.
+    See **Fit Context** ([View](/examples/fit_context/) | [Editable](/examples/fit_context/edit/)) for an interactive demonstration of the `_fit_context` decorator.
 
 ### Parameter Interface
 
@@ -122,9 +122,9 @@ wrapper.set_params(nested__alpha=0.5)
 ```
 
 !!! example "Interactive Examples"
-    - [**Parameter Interface**](/examples/parameter_interface/) demonstrates `get_params()`/`set_params()` usage
-    - [**Nested Wrappers**](/examples/nested_wrappers/) shows nested parameter syntax with `__` delimiter
-    - [**GridSearch**](/examples/grid_search/) illustrates parameter tuning with `GridSearchCV`
+    - **Parameter Interface** ([View](/examples/parameter_interface/) | [Editable](/examples/parameter_interface/edit/)) demonstrates `get_params()`/`set_params()` usage
+    - **Nested Wrappers** ([View](/examples/nested_wrappers/) | [Editable](/examples/nested_wrappers/edit/)) shows nested parameter syntax with `__` delimiter
+    - **GridSearch** ([View](/examples/grid_search/) | [Editable](/examples/grid_search/edit/)) illustrates parameter tuning with `GridSearchCV`
 
 ## Configuration
 
@@ -234,7 +234,7 @@ class MyWrapper(BaseClassWrapper):
 ```
 
 !!! example "Interactive Example"
-    See [**Validation**](/examples/validation/) for an interactive demonstration of parameter validation and error handling.
+    See **Validation** ([View](/examples/validation/) | [Editable](/examples/validation/edit/)) for an interactive demonstration of parameter validation and error handling.
 
 ### 4. Handle Nested Estimators Carefully
 
@@ -283,7 +283,7 @@ class XGBoostWrapper(BaseClassWrapper):
 ```
 
 !!! example "Interactive Example"
-    See [**XGBoost**](/examples/xgboost_wrapper/) for a complete implementation of an XGBoost wrapper.
+    See **XGBoost** ([View](/examples/xgboost_wrapper/) | [Editable](/examples/xgboost_wrapper/edit/)) for a complete implementation of an XGBoost wrapper.
 
 ## Limitations and Considerations
 
@@ -296,7 +296,7 @@ Understanding the limitations helps you make informed decisions:
 3. **Metadata routing to nested estimators**: Sklearn-wrap does not currently implement metadata routing to nested estimators within the wrapper. The wrapper itself can consume metadata (e.g., `sample_weight` in `fit()`), but cannot automatically route it to nested wrapped estimators. You must handle routing manually in your wrapper's methods if needed.
 
 !!! example "Additional Example"
-    See [**Serialization**](/examples/serialization/) for an interactive demonstration of saving and loading wrapped estimators with `joblib`.
+    See **Serialization** ([View](/examples/serialization/) | [Editable](/examples/serialization/edit/)) for an interactive demonstration of saving and loading wrapped estimators with `joblib`.
 
 ## Next Steps
 

--- a/examples/first_wrapper.py
+++ b/examples/first_wrapper.py
@@ -24,21 +24,32 @@ async def _():
 
 @app.cell(hide_code=True)
 def _():
-    # Imports
     import marimo as mo
+    return (mo,)
+
+
+@app.cell(hide_code=True)
+def _():
     import numpy as np
 
     from sklearn_wrap import BaseClassWrapper
 
-    return BaseClassWrapper, mo, np
+    return BaseClassWrapper, np
 
 
 @app.cell(hide_code=True)
 def _(mo):
     mo.md("""
-    ## Overview
+    ## What You'll Learn
 
-    Learn how to wrap any Python class into a scikit-learn compatible estimator using `BaseClassWrapper`. This notebook demonstrates the core pattern by wrapping a custom polynomial regression algorithm that uses gradient descent and doesn't follow sklearn conventions.
+    - How to wrap a non-sklearn Python class into a scikit-learn compatible estimator
+    - The three essential components every wrapper needs: `_estimator_name`, `_estimator_base_class`, and `fit`/`predict`
+    - How to bridge custom method names (e.g., `train`/`compute_predictions`) to sklearn's `fit`/`predict` interface
+    - Interactive hyperparameter control with wrapped estimators
+
+    ## Prerequisites
+
+    None -- this is the starting point.
     """)
     return
 
@@ -232,7 +243,7 @@ def create_regression_scatter(X_train, y_train, X_test, y_test, X_plot, y_pred_p
     return fig
 
 
-@app.cell(hide_code=True)
+@app.cell
 def _(
     X_plot,
     X_test,
@@ -293,12 +304,11 @@ def _(mo):
     mo.md("""
     ## Key Takeaways
 
-    - Custom algorithm now works with sklearn ecosystem
-    - Works with `GridSearchCV` for hyperparameter tuning
-    - Compatible with `Pipeline` for preprocessing chains
-    - Supports `joblib` serialization
-    - Automatic parameter validation
-    - Clean HTML representation in interactive notebooks
+    - **BaseClassWrapper** bridges any Python class to sklearn's interface
+    - **`_estimator_name` and `_estimator_base_class`** are required class attributes for every wrapper
+    - **Method delegation** maps custom method names to sklearn's `fit`/`predict` convention
+    - **sklearn ecosystem** integration (GridSearchCV, Pipeline, joblib) works automatically
+    - **Parameter validation** and HTML representation come for free
     """)
     return
 

--- a/examples/fit_context.py
+++ b/examples/fit_context.py
@@ -24,19 +24,31 @@ async def _():
 @app.cell(hide_code=True)
 def _():
     import marimo as mo
+    return (mo,)
+
+
+@app.cell(hide_code=True)
+def _():
     import numpy as np
 
     from sklearn_wrap import BaseClassWrapper
     from sklearn_wrap.base import _fit_context
-    return BaseClassWrapper, mo, np, _fit_context
+    return BaseClassWrapper, np, _fit_context
 
 
 @app.cell(hide_code=True)
 def _(mo):
     mo.md("""
-    ## Overview
+    ## What You'll Learn
 
-    Understand how the `_fit_context` decorator automates parameter validation and instantiation in fit methods. This decorator is sklearn-wrap's implementation of sklearn's fit context management pattern, handling validation, instantiation, nested validation control, and fitted state management automatically. Learn when to use `prefer_skip_nested_validation=True` versus `False`.
+    - What the `_fit_context` decorator automates: validation, instantiation, and fitted state management
+    - The difference between manual `instantiate()`/`_validate_params()` calls and the decorator approach
+    - When to use `prefer_skip_nested_validation=True` versus `False`
+    - How the decorator handles `partial_fit` for incremental learning
+
+    ## Prerequisites
+
+    Familiarity with first_wrapper.py.
     """)
     return
 
@@ -81,7 +93,7 @@ def _(np):
 @app.cell(hide_code=True)
 def _(mo):
     mo.md("""
-    ## Manual Approach (Explicit Calls)
+    ### Manual Approach (Explicit Calls)
     """)
     return
 
@@ -111,7 +123,7 @@ def _(BaseClassWrapper):
 @app.cell(hide_code=True)
 def _(mo):
     mo.md("""
-    ## Decorator Approach (Automatic)
+    ### Decorator Approach (Automatic)
 
     The decorator accepts `prefer_skip_nested_validation` parameter.
     """)
@@ -132,7 +144,6 @@ def _(BaseClassWrapper, _fit_context):
 
         def predict(self, X):
             return self.instance_.get_predictions(X)
-            return self.instance_.predict(X)
     return (DecoratorWrapper,)
 
 
@@ -161,7 +172,7 @@ def _(mo):
 @app.cell(hide_code=True)
 def _(mo):
     mo.md("""
-    ## Compare Both Approaches
+    ### Compare Both Approaches
     """)
     return
 
@@ -190,11 +201,11 @@ def _(decorator_pred, manual_pred, mo):
 
     **Decorator Predictions:** {decorator_pred}
 
-    ✓ Both produce identical results
+    Both produce identical results.
 
-    ✓ Decorator approach reduces boilerplate
+    The decorator approach reduces boilerplate.
 
-    ✓ Validation happens automatically
+    Validation happens automatically.
     """)
     return
 
@@ -202,7 +213,7 @@ def _(decorator_pred, manual_pred, mo):
 @app.cell(hide_code=True)
 def _(mo):
     mo.md("""
-    ## Decorator Benefits
+    ### Decorator Benefits
 
     **Automatic instantiation:** No need to call `instantiate()` explicitly
 
@@ -288,11 +299,11 @@ def _(mo):
     mo.md("""
     ## Key Takeaways
 
-    - `_fit_context` decorator automates validation and instantiation
-    - Use `prefer_skip_nested_validation=True` for most wrappers (performance)
-    - Use `prefer_skip_nested_validation=False` for meta-estimators (safety)
-    - Decorator handles `partial_fit` specially for incremental learning
-    - Automatically sets `fitted_` attribute after successful fit
+    - **`_fit_context`** automates validation, instantiation, and fitted state management
+    - **`prefer_skip_nested_validation=True`** is recommended for most wrappers to avoid redundant checks
+    - **`prefer_skip_nested_validation=False`** is appropriate for meta-estimators that accept user-provided estimator objects
+    - **`partial_fit`** is handled specially: the decorator skips re-instantiation on subsequent calls
+    - **`fitted_` attribute** is set automatically after successful fit when using the decorator
     """)
     return
 

--- a/examples/grid_search.py
+++ b/examples/grid_search.py
@@ -24,20 +24,32 @@ async def _():
 @app.cell(hide_code=True)
 def _():
     import marimo as mo
+    return (mo,)
+
+
+@app.cell(hide_code=True)
+def _():
     import numpy as np
     from sklearn.model_selection import GridSearchCV
 
     from sklearn_wrap import BaseClassWrapper
 
-    return BaseClassWrapper, GridSearchCV, mo, np
+    return BaseClassWrapper, GridSearchCV, np
 
 
 @app.cell(hide_code=True)
 def _(mo):
     mo.md("""
-    ## Overview
+    ## What You'll Learn
 
-    Use GridSearchCV to automatically find optimal hyperparameters for wrapped estimators. This notebook demonstrates how BaseClassWrapper's parameter interface integrates seamlessly with sklearn's hyperparameter search tools, enabling exhaustive grid search with cross-validation.
+    - How to use GridSearchCV with wrapped estimators for automated hyperparameter tuning
+    - How BaseClassWrapper's parameter interface integrates seamlessly with sklearn's search tools
+    - How to define parameter grids and interpret cross-validation results
+    - How wrapped estimators display in sklearn meta-estimator HTML representations
+
+    ## Prerequisites
+
+    Familiarity with first_wrapper.py and parameter_interface.py.
     """)
     return
 
@@ -221,7 +233,7 @@ def _(cv_results, np):
 @app.cell(hide_code=True)
 def _(mo):
     mo.md("""
-    ## HTML Representation
+    ## 4. HTML Representation
 
     GridSearchCV meta-estimators display correctly with wrapped estimators.
     """)
@@ -261,10 +273,10 @@ def _(mo):
     mo.md("""
     ## Key Takeaways
 
-    - GridSearchCV works seamlessly with wrapped estimators
-    - All sklearn tools (cross-validation, scoring) integrate automatically
-    - Parameter validation happens through BaseClassWrapper
-    - HTML representations display correctly for meta-estimators
+    - **GridSearchCV** works seamlessly with wrapped estimators through the parameter interface
+    - **Cross-validation** and scoring integrate automatically with no extra code in the wrapper
+    - **Parameter validation** happens through BaseClassWrapper during each grid search iteration
+    - **HTML representations** display correctly for meta-estimators containing wrappers
     """)
     return
 

--- a/examples/nested_wrappers.py
+++ b/examples/nested_wrappers.py
@@ -24,19 +24,31 @@ async def _():
 @app.cell(hide_code=True)
 def _():
     import marimo as mo
+    return (mo,)
+
+
+@app.cell(hide_code=True)
+def _():
     import numpy as np
 
     from sklearn_wrap import BaseClassWrapper
 
-    return BaseClassWrapper, mo, np
+    return BaseClassWrapper, np
 
 
 @app.cell(hide_code=True)
 def _(mo):
     mo.md("""
-    ## Overview
+    ## What You'll Learn
 
-    Master the double-underscore (`__`) syntax for controlling parameters in nested estimator hierarchies. When wrappers contain other wrappers, sklearn's parameter interface uses `outer__inner__param` notation to access nested parameters. This enables GridSearchCV to search complex parameter spaces and allows precise control over deeply nested structures.
+    - How the double-underscore (`__`) syntax controls parameters in nested estimator hierarchies
+    - How `get_params(deep=True)` expands nested parameter structures
+    - How to use `set_params()` with `__` notation to modify parameters at any nesting depth
+    - How nested estimators display in HTML representations
+
+    ## Prerequisites
+
+    Familiarity with first_wrapper.py and parameter_interface.py.
     """)
     return
 
@@ -246,7 +258,7 @@ def _(
     return fig, train_r2, test_r2
 
 
-@app.function
+@app.function(hide_code=True)
 def generate_regression_data(n_samples=300, n_features=2, noise=20, test_size=0.3, random_state=42, **kwargs):
     from sklearn.datasets import make_regression
     from sklearn.model_selection import train_test_split
@@ -337,11 +349,11 @@ def _(mo):
     mo.md("""
     ## Key Takeaways
 
-    - Use `estimator__param` to access nested parameters
-    - Works with any depth of nesting
-    - GridSearchCV can search nested parameter spaces
-    - `get_params(deep=True)` shows full hierarchy
-    - HTML representation shows complete nested structure
+    - **`estimator__param` syntax** accesses nested parameters at any depth
+    - **`get_params(deep=True)`** reveals the full parameter hierarchy
+    - **GridSearchCV** can search nested parameter spaces using `__` notation
+    - **`set_params()`** with `__` syntax modifies nested parameters without recreating the estimator
+    - **HTML representation** shows the complete nested structure
     """)
     return
 

--- a/examples/parameter_interface.py
+++ b/examples/parameter_interface.py
@@ -25,18 +25,30 @@ async def _():
 @app.cell(hide_code=True)
 def _():
     import marimo as mo
+    return (mo,)
+
+
+@app.cell(hide_code=True)
+def _():
     import numpy as np
 
     from sklearn_wrap import BaseClassWrapper
-    return BaseClassWrapper, mo, np
+    return BaseClassWrapper, np
 
 
 @app.cell(hide_code=True)
 def _(mo):
     mo.md("""
-    ## Overview
+    ## What You'll Learn
 
-    Master the `get_params()` and `set_params()` interface that makes sklearn's ecosystem work. These methods enable GridSearchCV to search hyperparameters, Pipeline to access nested parameters, and allow interactive parameter updates. Understanding this interface is essential for effective wrapper usage.
+    - How `get_params()` and `set_params()` work under the hood in wrapped estimators
+    - Why sklearn needs this parameter interface for GridSearchCV, Pipeline, and cloning
+    - How to dynamically update parameters and understand when changes take effect
+    - What happens when you pass invalid parameters
+
+    ## Prerequisites
+
+    Familiarity with first_wrapper.py.
     """)
     return
 
@@ -124,7 +136,7 @@ def _(create_slider, mo):
     return alpha_slider, beta_slider
 
 
-@app.function
+@app.function(hide_code=True)
 def generate_regression_data(n_samples=300, n_features=2, noise=20, test_size=0.3, random_state=42, **kwargs):
     from sklearn.datasets import make_regression
     from sklearn.model_selection import train_test_split
@@ -185,7 +197,7 @@ def create_regression_scatter(X_train, y_train, X_test, y_test, X_plot, y_pred_p
     return fig
 
 
-@app.cell(hide_code=True)
+@app.cell
 def _(
     X_plot,
     X_test,
@@ -302,6 +314,20 @@ def _(error_msg, mo, updated_params):
 
     BaseClassWrapper validates against the wrapped class's `__init__` signature.
     Only parameters defined in `ConfigurableRegressor.__init__` are allowed.
+    """)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md("""
+    ## Key Takeaways
+
+    - **`get_params()`** returns all constructor parameters of the wrapped class plus the estimator class itself
+    - **`set_params()`** validates parameter names against the wrapped class's `__init__` and updates them dynamically
+    - **Parameter changes** only take effect after calling `fit()` again, since the wrapped instance is recreated during `instantiate()`
+    - **Invalid parameters** raise `ValueError` immediately, catching mistakes before runtime
+    - **sklearn integration** depends entirely on this interface for GridSearchCV, Pipeline, and `clone()`
     """)
     return
 

--- a/examples/serialization.py
+++ b/examples/serialization.py
@@ -23,8 +23,13 @@ async def _():
 
 
 @app.cell(hide_code=True)
-def __():
+def _():
     import marimo as mo
+    return (mo,)
+
+
+@app.cell(hide_code=True)
+def _():
     import numpy as np
     import tempfile
     from pathlib import Path
@@ -40,17 +45,23 @@ def __():
 
 
 @app.cell(hide_code=True)
-def __(mo):
+def _(mo):
     mo.md("""
-    ## Overview
+    ## What You'll Learn
 
-    Save and load wrapped estimators using joblib, just like any sklearn estimator. Serialization preserves all state including fitted parameters, wrapped instances, and nested structures. This notebook demonstrates persistence for simple estimators, pipelines, and GridSearchCV meta-estimators.
+    - How to save and load wrapped estimators using joblib
+    - How pipelines containing wrapped estimators serialize correctly
+    - How GridSearchCV meta-estimators preserve all state including cross-validation results
+
+    ## Prerequisites
+
+    Familiarity with first_wrapper.py.
     """)
     return
 
 
 @app.cell(hide_code=True)
-def __(mo):
+def _(mo):
     mo.md("""
     ## 1. Estimator Serialization
 
@@ -60,7 +71,7 @@ def __(mo):
 
 
 @app.cell
-def __(np):
+def _(np):
     class SimpleRegressor:
         """A simple regressor without sklearn conventions."""
 
@@ -79,7 +90,7 @@ def __(np):
 
 
 @app.cell
-def __(BaseClassWrapper):
+def _(BaseClassWrapper):
     class SimpleWrapper(BaseClassWrapper):
         _estimator_name = "regressor"
         _estimator_base_class = object
@@ -95,7 +106,7 @@ def __(BaseClassWrapper):
     return (SimpleWrapper,)
 
 
-@app.function
+@app.function(hide_code=True)
 def generate_regression_data(n_samples=100, n_features=1, noise=1.0, random_state=42):
     from sklearn.datasets import make_regression
     from sklearn.model_selection import train_test_split
@@ -104,7 +115,7 @@ def generate_regression_data(n_samples=100, n_features=1, noise=1.0, random_stat
 
 
 @app.cell
-def __(SimpleRegressor, SimpleWrapper, generate_regression_data):
+def _(SimpleRegressor, SimpleWrapper, generate_regression_data):
     # Train and fit
     X_train, X_test, y_train, y_test = generate_regression_data()
 
@@ -117,7 +128,7 @@ def __(SimpleRegressor, SimpleWrapper, generate_regression_data):
 
 
 @app.cell
-def __(estimator, joblib, tempfile):
+def _(estimator, joblib, tempfile):
     # Save to file
     temp_dir = tempfile.mkdtemp()
     estimator_path = f"{temp_dir}/estimator.pkl"
@@ -129,7 +140,7 @@ def __(estimator, joblib, tempfile):
 
 
 @app.cell
-def __(loaded_estimator, X_test, y_test, original_predictions, original_score, mo, np):
+def _(loaded_estimator, X_test, y_test, original_predictions, original_score, mo, np):
     # Verify loaded estimator works
     loaded_predictions = loaded_estimator.predict(X_test)
     loaded_score = np.mean((loaded_predictions - y_test) ** 2)
@@ -147,7 +158,7 @@ def __(loaded_estimator, X_test, y_test, original_predictions, original_score, m
 
 
 @app.cell(hide_code=True)
-def __(mo):
+def _(mo):
     mo.md("""
     ## 2. Pipeline Serialization
 
@@ -157,7 +168,7 @@ def __(mo):
 
 
 @app.cell
-def __(SimpleRegressor, SimpleWrapper, StandardScaler, Pipeline, X_test, X_train, y_train):
+def _(SimpleRegressor, SimpleWrapper, StandardScaler, Pipeline, X_test, X_train, y_train):
     # Create and fit pipeline
     pipeline = Pipeline([
         ("scaler", StandardScaler()),
@@ -170,7 +181,7 @@ def __(SimpleRegressor, SimpleWrapper, StandardScaler, Pipeline, X_test, X_train
 
 
 @app.cell
-def __(pipeline, joblib, temp_dir):
+def _(pipeline, joblib, temp_dir):
     # Save and load pipeline
     pipeline_path = f"{temp_dir}/pipeline.pkl"
     joblib.dump(pipeline, pipeline_path)
@@ -179,14 +190,14 @@ def __(pipeline, joblib, temp_dir):
 
 
 @app.cell
-def __(loaded_pipeline, X_test):
+def _(loaded_pipeline, X_test):
     # Verify pipeline
     loaded_pipeline_predictions = loaded_pipeline.predict(X_test)
     return loaded_pipeline_predictions
 
 
 @app.cell(hide_code=True)
-def __(mo, np, pipeline_predictions, loaded_pipeline_predictions, loaded_pipeline):
+def _(mo, np, pipeline_predictions, loaded_pipeline_predictions, loaded_pipeline):
     mo.md(f"""
     ### Pipeline Serialization
 
@@ -199,7 +210,7 @@ def __(mo, np, pipeline_predictions, loaded_pipeline_predictions, loaded_pipelin
 
 
 @app.cell(hide_code=True)
-def __(mo):
+def _(mo):
     mo.md("""
     ## 3. GridSearchCV Serialization
 
@@ -209,7 +220,7 @@ def __(mo):
 
 
 @app.cell
-def __(SimpleRegressor, SimpleWrapper, GridSearchCV, X_test, X_train, y_train):
+def _(SimpleRegressor, SimpleWrapper, GridSearchCV, X_test, X_train, y_train):
     # Run grid search
     grid = GridSearchCV(
         SimpleWrapper(regressor=SimpleRegressor),
@@ -225,7 +236,7 @@ def __(SimpleRegressor, SimpleWrapper, GridSearchCV, X_test, X_train, y_train):
 
 
 @app.cell(hide_code=True)
-def __(grid, joblib, temp_dir):
+def _(grid, joblib, temp_dir):
     # Save and load grid search
     grid_path = f"{temp_dir}/grid.pkl"
     joblib.dump(grid, grid_path)
@@ -234,14 +245,14 @@ def __(grid, joblib, temp_dir):
 
 
 @app.cell
-def __(loaded_grid, X_test, grid_predictions, best_params, mo, np):
+def _(loaded_grid, X_test, grid_predictions, best_params, mo, np):
     # Verify grid search
     loaded_grid_predictions = loaded_grid.predict(X_test)
     return loaded_grid_predictions
 
 
 @app.cell(hide_code=True)
-def __(loaded_grid, best_params, grid_predictions, loaded_grid_predictions,  mo, np):
+def _(loaded_grid, best_params, grid_predictions, loaded_grid_predictions,  mo, np):
     mo.md(f"""
     ### GridSearchCV Serialization
 
@@ -256,19 +267,19 @@ def __(loaded_grid, best_params, grid_predictions, loaded_grid_predictions,  mo,
 
 
 @app.cell(hide_code=True)
-def __(mo):
+def _(mo):
     mo.md("""
     ## Key Takeaways
 
-    - Wrapped estimators serialize with `joblib.dump()` and `pickle`
-    - Pipelines containing wrappers persist correctly
-    - Meta-estimators like GridSearchCV save all state
+    - **`joblib.dump()`** and `joblib.load()` work seamlessly with wrapped estimators
+    - **Pipelines** containing wrappers persist and restore all preprocessing steps correctly
+    - **GridSearchCV** saves complete state including best estimator and all cross-validation results
     """)
     return
 
 
 @app.cell(hide_code=True)
-def __(mo):
+def _(mo):
     mo.md("""
     ## Next Steps
 

--- a/examples/validation.py
+++ b/examples/validation.py
@@ -24,19 +24,31 @@ async def _():
 @app.cell(hide_code=True)
 def _():
     import marimo as mo
+    return (mo,)
+
+
+@app.cell(hide_code=True)
+def _():
     import numpy as np
     from sklearn.base import BaseEstimator
 
     from sklearn_wrap import BaseClassWrapper
-    return BaseClassWrapper, BaseEstimator, mo, np
+    return BaseClassWrapper, BaseEstimator, np
 
 
 @app.cell(hide_code=True)
 def _(mo):
     mo.md("""
-    ## Overview
+    ## What You'll Learn
 
-    Learn common error patterns when wrapping classes and how BaseClassWrapper provides early validation to catch mistakes before runtime. This notebook covers invalid parameters, wrong base classes, missing required parameters, reserved delimiters, and parameter constraints for type safety.
+    - Five common error patterns when wrapping classes and how to diagnose them
+    - How BaseClassWrapper validates parameters against the wrapped class's constructor
+    - How to enforce base class requirements with `_estimator_base_class`
+    - How to use `_parameter_constraints` for type-safe nested wrapper composition
+
+    ## Prerequisites
+
+    Familiarity with first_wrapper.py.
     """)
     return
 
@@ -44,7 +56,7 @@ def _(mo):
 @app.cell(hide_code=True)
 def _(mo):
     mo.md("""
-    ## Error Pattern 1: Invalid Parameters
+    ## 1. Invalid Parameters
 
     BaseClassWrapper validates against the wrapped class's constructor signature.
     """)
@@ -110,7 +122,7 @@ def _(create_error_demo, invalid_param_operation):
 @app.cell(hide_code=True)
 def _(mo):
     mo.md("""
-    ## Error Pattern 2: Wrong Base Class
+    ## 2. Wrong Base Class
 
     Enforce that wrapped classes inherit from required base classes.
     """)
@@ -154,7 +166,7 @@ def _(create_error_demo, wrong_base_operation):
 @app.cell(hide_code=True)
 def _(mo):
     mo.md("""
-    ## Error Pattern 3: Missing Required Parameters
+    ## 3. Missing Required Parameters
 
     Parameters without defaults must be provided during instantiation.
     """)
@@ -194,7 +206,7 @@ def _(create_error_demo, missing_required_operation):
 @app.cell(hide_code=True)
 def _(mo):
     mo.md("""
-    ## Error Pattern 4: Double Underscore Reserved
+    ## 4. Double Underscore Reserved
 
     The `__` delimiter is reserved for nested parameter syntax.
     """)
@@ -222,7 +234,7 @@ def _(create_error_demo, reserved_delimiter_operation):
 @app.cell(hide_code=True)
 def _(mo):
     mo.md("""
-    ## Error Pattern 5: Parameter Constraints
+    ## 5. Parameter Constraints
 
     Use `_parameter_constraints` to enforce type and inheritance requirements on parameters.
     """)
@@ -349,7 +361,7 @@ def _(EnsembleModel, EnsembleWrapper, RegressorWrapper, SimpleRegressor, np):
 @app.cell(hide_code=True)
 def _(mo, ensemble_predictions):
     mo.md(f"""
-    ✓ Valid ensemble created and fitted successfully
+    Valid ensemble created and fitted successfully
 
     **Predictions:** {ensemble_predictions}
 
@@ -361,13 +373,13 @@ def _(mo, ensemble_predictions):
 @app.cell(hide_code=True)
 def _(mo):
     mo.md("""
-    ## Best Practices
+    ## Key Takeaways
 
-    - Define `_estimator_base_class` to enforce inheritance requirements
-    - Use `_parameter_constraints` for nested wrapper validation
-    - Use `get_params()` to inspect available parameters
-    - Let BaseClassWrapper validate before `instantiate()` is called
-    - Provide default values in wrapped class for optional parameters
+    - **`_estimator_base_class`** enforces inheritance requirements on the wrapped class
+    - **`_parameter_constraints`** enables type-safe validation for nested wrapper parameters
+    - **Parameter validation** catches invalid, missing, and reserved parameter names early
+    - **`get_params()`** helps inspect available parameters before setting them
+    - **Default values** should be provided in the wrapped class for optional parameters
     """)
     return
 

--- a/examples/xgboost_wrapper.py
+++ b/examples/xgboost_wrapper.py
@@ -24,22 +24,32 @@ async def _():
 @app.cell(hide_code=True)
 def _():
     import marimo as mo
+    return (mo,)
+
+
+@app.cell(hide_code=True)
+def _():
     import numpy as np
     import xgboost as xgb
 
     from sklearn_wrap import BaseClassWrapper
 
-    return BaseClassWrapper, mo, np, xgb
+    return BaseClassWrapper, np, xgb
 
 
 @app.cell(hide_code=True)
 def _(mo):
     mo.md("""
-    ## Overview
+    ## What You'll Learn
 
-    Wrap XGBoost's low-level Booster API to make it sklearn-compatible. XGBoost's native API uses DMatrix objects and doesn't follow sklearn conventions. This notebook shows how to bridge the gap by creating an adapter class that wraps `xgb.train()`, enabling XGBoost to work with GridSearchCV, Pipelines, and other sklearn tools.
+    - How to wrap XGBoost's low-level Booster API for sklearn compatibility
+    - How to create an adapter class to bridge procedural APIs (`xgb.train()`) to a class-based interface
+    - How nested wrappers enable callback parameter control via `__` syntax
+    - How `_parameter_constraints` and `_estimator_default_class` simplify wrapper configuration
 
-    This example also demonstrates **nested wrappers** by wrapping XGBoost callbacks. The nested parameter syntax (`callbacks__period=5`) works automatically through BaseClassWrapper's built-in `get_params`/`set_params` - no manual override needed!
+    ## Prerequisites
+
+    Familiarity with first_wrapper.py.
     """)
     return
 
@@ -135,6 +145,14 @@ def _(BaseClassWrapper, xgb):
             return self.instance_.predict_output(X)
 
     return XGBoostCallbackWrapper, XGBoostTrainer, XGBoostTrainerWrapper
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md("""
+    ## 2. Interactive Demo
+    """)
+    return
 
 
 @app.function(hide_code=True)
@@ -236,7 +254,7 @@ def _(
 @app.cell(hide_code=True)
 def _(mo):
     mo.md("""
-    ## HTML Representation
+    ## 4. HTML Representation
 
     Wrapped XGBoost models display correctly.
     """)
@@ -260,7 +278,7 @@ def _(wrapper):
 @app.cell(hide_code=True)
 def _(mo):
     mo.md("""
-    ## 4. Nested Parameter Control
+    ## 5. Nested Parameter Control
 
     Use the `__` syntax to control callback parameters.
     """)
@@ -304,12 +322,12 @@ def _(mo):
     mo.md("""
     ## Key Takeaways
 
-    - Low-level XGBoost API now sklearn-compatible
+    - **Low-level XGBoost API** becomes sklearn-compatible through an adapter class pattern
     - **Nested wrapper pattern** enables callback control via `__` syntax
-    - Works with GridSearchCV for hyperparameter tuning (including callback params)
-    - Can be used in sklearn Pipelines
-    - Custom DMatrix handling integrated seamlessly
-    - Clean HTML representation with nested structure
+    - **`_parameter_constraints`** validates that callbacks inherit from `TrainingCallback`
+    - **`_estimator_default_class`** eliminates the need to pass the wrapped class every time
+    - **DMatrix handling** is integrated seamlessly inside the adapter class
+    - **HTML representation** shows the complete nested structure
     """)
     return
 


### PR DESCRIPTION
## Description

Update from copier template v0.13.0 and align all 8 notebook examples with the contributing guidelines.

## Type of Change

- [x] Documentation update
- [x] Refactoring (no functional changes)

## Motivation and Context

The copier template had upstream changes. The notebook examples predated the current contributing guidelines and needed structural alignment (intro sections, section numbering, Key Takeaways formatting, hide_code conventions, emoji removal).

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just format` to format my code
- [x] I have updated the documentation accordingly
- [x] All new and existing tests passed
- [x] My changes generate no new warnings