### PR TITLE
docs: reformulate docs text

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,7 @@
 # This file is used by Copier to track the template version
 # and enable template updates in generated projects
 
-_commit: b1350d0e5e9792ccf86faba9ee3899075a622462
+_commit: f4f1d235602eafd3c611bd4fa8c1efe427acde5c
 _src_path: gh:stateful-y/python-package-copier
 author_email: gtauzin@stateful-y.io
 author_name: Guillaume Tauzin

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 Sklearn-wrap enables you to wrap any Python class into a scikit-learn compatible estimator without rewriting your code. Whether you're integrating XGBoost's Booster API, custom gradient descent algorithms, or third-party machine learning libraries, sklearn-wrap provides the glue layer that makes them work seamlessly with sklearn's ecosystem.
 
-With sklearn-wrap, you gain immediate access to GridSearchCV for hyperparameter tuning, Pipeline for composable workflows, and joblib for serialization—all while maintaining your original implementation. Perfect for data scientists who want sklearn compatibility without sacrificing custom logic or performance.
+With sklearn-wrap, you gain immediate access to GridSearchCV for hyperparameter tuning, Pipeline for composable workflows, and joblib for serialization, all while maintaining your original implementation. Perfect for data scientists who want sklearn compatibility without sacrificing custom logic or performance.
 
 ## What are the features of Sklearn-Wrap?
 

--- a/docs/pages/contributing.md
+++ b/docs/pages/contributing.md
@@ -422,7 +422,7 @@ Create a new marimo notebook in `examples/<name>.py`:
        return
    ```
 
-   **`hide_code=True` guidance** — mark these cells as hidden:
+   **`hide_code=True` guidance**: mark these cells as hidden:
 
    | Cell type | Why hidden |
    |-----------|-----------|

--- a/docs/pages/contributing.md
+++ b/docs/pages/contributing.md
@@ -422,7 +422,7 @@ Create a new marimo notebook in `examples/<name>.py`:
        return
    ```
 
-   **`hide_code=True` guidance**: mark these cells as hidden:
+   **`hide_code=True` guidance:** mark these cells as hidden:
 
    | Cell type | Why hidden |
    |-----------|-----------|


### PR DESCRIPTION
## Description

Replace em-dashes (—) with standard punctuation in documentation files.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Motivation and Context

Em-dashes can cause rendering inconsistencies across different platforms. Replaced with colons and commas for clarity.

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just format` to format my code
- [x] I have run `just check` to verify type annotations
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings

## Additional Notes

Two replacements:
- `README.md`: `serialization—all` → `serialization, all`
- `docs/pages/contributing.md`: `guidance** —` → `guidance**:`