### PR TITLE
feat: update from template v0.14.0 with PEP 723 and marimo playground links

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,7 @@
 # This file is used by Copier to track the template version
 # and enable template updates in generated projects
 
-_commit: fdb4552a1ec1bc4eb78639a915006609cc9e2ded
+_commit: d439e067d6a4a123dc84d1c27642e2cd03356d67
 _src_path: gh:stateful-y/python-package-copier
 author_email: gtauzin@stateful-y.io
 author_name: Guillaume Tauzin

--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -1,6 +1,7 @@
 """MkDocs hooks for post-build processing."""
 
 import fnmatch
+import os
 import re
 import shutil
 import subprocess
@@ -10,21 +11,38 @@ from pathlib import Path
 
 
 def on_page_markdown(markdown, page, config, files):
-    """Rewrite example links to work in both local and RTD environments.
+    """Rewrite example links for both local and RTD environments.
 
-    Converts absolute paths like /examples/ to relative paths based on page depth.
-    This works on both local builds and Read the Docs.
+    [View] links are converted to relative paths pointing to locally exported
+    static HTML notebooks.
+
+    [Open in marimo] placeholder links are resolved to the marimo online
+    playground via marimo.app. On RTD the commit SHA being built is used so
+    PR previews link to the correct revision; locally, ``main`` is used.
     """
-    # Calculate relative path based on page depth
+    # Calculate relative path based on page depth (used on all builds)
     src_parts = page.file.src_path.split("/")
-
-    # Calculate depth (pages/examples.md has depth 2, index.md has depth 0)
     depth = len(src_parts) if src_parts[-1] != "index.md" else len(src_parts) - 1
-
-    # Build relative prefix: '../' repeated for each directory level
     prefix = "../" * depth
 
-    # Replace absolute paths with relative paths
+    repo_url = config.get("repo_url", "").rstrip("/")
+    github_path = repo_url.removeprefix("https://")
+    # READTHEDOCS_GIT_IDENTIFIER is the PR number for pull-request builds,
+    # which is not a valid git ref.  READTHEDOCS_GIT_COMMIT_HASH is always
+    # the actual commit SHA checked out by RTD.
+    git_ref = os.environ.get(
+        "READTHEDOCS_GIT_COMMIT_HASH",
+        os.environ.get("READTHEDOCS_GIT_IDENTIFIER", "main"),
+    )
+    playground_base = f"https://marimo.app/{github_path}/blob/{git_ref}"
+
+    # Resolve [Open in marimo] placeholder URLs → full marimo.app playground URLs
+    markdown = re.sub(
+        r"\[Open in marimo\]\(/examples/([^)]+?)/edit/\)",
+        rf"[Open in marimo]({playground_base}/examples/\1.py)",
+        markdown,
+    )
+    # Rewrite [View] to relative paths pointing to local HTML exports
     markdown = re.sub(r"\]\(/examples/", f"]({prefix}examples/", markdown)
     return markdown
 
@@ -40,16 +58,22 @@ def on_pre_build(config):
     if not examples_dir.exists():
         return
 
-    # Find all marimo notebooks
-    notebooks = list(examples_dir.glob("*.py"))
+    # Find all marimo notebooks (recursively, excluding __marimo__ and bugs dirs)
+    notebooks = [
+        p
+        for p in examples_dir.rglob("*.py")
+        if "__marimo__" not in p.parts and "bugs" not in p.parts and "__init__" not in p.name
+    ]
     if not notebooks:
         return
 
     docs_examples = project_root / "docs" / "examples"
     docs_examples.mkdir(parents=True, exist_ok=True)
 
-    # Export each notebook in both static HTML and interactive WASM formats
+    failed: list[str] = []
+
     for notebook in notebooks:
+        rel_path = notebook.relative_to(project_root)
         output_dir = docs_examples / notebook.stem
 
         # Clean previous export artifacts before re-exporting
@@ -69,6 +93,7 @@ def on_pre_build(config):
                     "-q",
                     "export",
                     "html",
+                    "--no-sandbox",
                     str(notebook),
                     "-o",
                     str(static_file),
@@ -77,52 +102,21 @@ def on_pre_build(config):
                 capture_output=True,
                 text=True,
             )
-            print(
-                f"[hooks] exported html {notebook.relative_to(project_root)} -> {static_file.relative_to(project_root)}"
-            )
+            print(f"[hooks] exported html {rel_path} -> {static_file.relative_to(project_root)}")
         except subprocess.CalledProcessError as e:
-            print(f"[hooks] Error exporting html {notebook.name}: {e}", file=sys.stderr)
+            failed.append(str(rel_path))
+            print(f"[hooks] FAILED html {rel_path}: {e}", file=sys.stderr)
             if e.stderr:
                 print(e.stderr, file=sys.stderr)
+            continue
         except FileNotFoundError:
             print("[hooks] marimo not found, skipping notebook export", file=sys.stderr)
             break
 
-        # Export interactive WASM (editable in-browser)
-        edit_dir = output_dir / "edit"
-        edit_file = edit_dir / "index.html"
-        edit_dir.mkdir(parents=True, exist_ok=True)
-
-        try:
-            subprocess.run(
-                [
-                    sys.executable,
-                    "-m",
-                    "marimo",
-                    "-y",
-                    "-q",
-                    "export",
-                    "html-wasm",
-                    str(notebook),
-                    "-o",
-                    str(edit_file),
-                    "--mode",
-                    "edit",
-                ],
-                check=True,
-                capture_output=True,
-                text=True,
-            )
-            print(
-                f"[hooks] exported html-wasm {notebook.relative_to(project_root)} -> {edit_file.relative_to(project_root)}"
-            )
-        except subprocess.CalledProcessError as e:
-            print(f"[hooks] Error exporting html-wasm {notebook.name}: {e}", file=sys.stderr)
-            if e.stderr:
-                print(e.stderr, file=sys.stderr)
-        except FileNotFoundError:
-            print("[hooks] marimo not found, skipping notebook export", file=sys.stderr)
-            break
+    if failed:
+        msg = f"[hooks] {len(failed)} notebook(s) had cell execution errors:\n"
+        msg += "\n".join(f"  - {f}" for f in failed)
+        raise RuntimeError(msg)
 
 
 class _HtmlToMarkdown(HTMLParser):
@@ -407,32 +401,6 @@ def _is_excluded(relative_posix: str, patterns: list[str]) -> bool:
     return any(fnmatch.fnmatch(relative_posix, pattern) for pattern in patterns)
 
 
-def _fix_marimo_filename(html_file: Path, notebook_name: str) -> None:
-    """Replace the default 'notebook.py' filename in marimo HTML exports.
-
-    Marimo exports always use 'notebook.py' as the default filename. This function
-    replaces it with the actual notebook name to show the correct title in browser tabs.
-
-    Note: Only the <marimo-filename> display tag is replaced. The config
-    ``"filename"`` field must stay as ``"notebook.py"`` because the marimo WASM
-    worker has that name hard-coded and writes the notebook source to
-    ``/marimo/notebook.py``. Changing the config value would cause a
-    ``FileNotFoundError`` at runtime.
-    """
-    if not html_file.exists():
-        return
-
-    html_content = html_file.read_text(encoding="utf-8")
-
-    # Replace the display tag
-    html_content = html_content.replace(
-        "<marimo-filename hidden>notebook.py</marimo-filename>",
-        f"<marimo-filename hidden>{notebook_name}.py</marimo-filename>",
-    )
-
-    html_file.write_text(html_content, encoding="utf-8")
-
-
 def _inject_rtd_css(html_file: Path) -> None:
     """Inject CSS to hide Read The Docs version menu flyout in marimo notebooks.
 
@@ -466,7 +434,7 @@ def on_post_build(config):
     project_root = Path(__file__).parent.parent
     docs_examples = project_root / "docs" / "examples"
 
-    # Copy standalone HTML example files (both static and WASM/edit)
+    # Copy standalone HTML example exports to site
     if docs_examples.exists():
         for html_dir in docs_examples.iterdir():
             if not html_dir.is_dir() or html_dir.name.startswith("."):
@@ -480,37 +448,15 @@ def on_post_build(config):
             target_dir = site_dir / "examples" / html_dir.name
             target_dir.mkdir(parents=True, exist_ok=True)
 
-            # Copy top-level files (static HTML export)
+            # Copy exported HTML files
             for file in html_dir.iterdir():
                 if file.name == "CLAUDE.md" or file.is_dir():
                     continue
                 shutil.copy2(file, target_dir / file.name)
 
-            # Inject CSS to hide RTD version menu in static HTML
+            # Inject CSS to hide RTD version menu in exported HTML
             _inject_rtd_css(target_dir / "index.html")
 
-            # Copy edit/ subdirectory (WASM export) if it exists
-            edit_src = html_dir / "edit"
-            if edit_src.exists() and edit_src.is_dir():
-                edit_target = target_dir / "edit"
-                if edit_target.exists():
-                    shutil.rmtree(edit_target)
-                shutil.copytree(
-                    edit_src,
-                    edit_target,
-                    ignore=shutil.ignore_patterns("CLAUDE.md"),
-                )
-
-                # Remove CLAUDE.md if MkDocs copied it from docs/ during build
-                claude_md = edit_target / "CLAUDE.md"
-                if claude_md.exists():
-                    claude_md.unlink()
-
-                # Fix the marimo filename in WASM export only
-                _fix_marimo_filename(edit_target / "index.html", html_dir.name)
-
-                # Inject CSS to hide RTD version menu in WASM export
-                _inject_rtd_css(edit_target / "index.html")
             print(f"[hooks] copied examples/{html_dir.name}/ to site")
 
     # Get exclude patterns from config

--- a/docs/pages/contributing.md
+++ b/docs/pages/contributing.md
@@ -10,7 +10,7 @@ We are committed to providing a welcoming and inclusive environment for all cont
 
 ### Prerequisites
 
-- Python +
+- Python 3.11+
 - [uv](https://github.com/astral-sh/uv) (recommended)
 - [just](https://github.com/casey/just) (optional, for task automation)
 - Git
@@ -23,7 +23,7 @@ We are committed to providing a welcoming and inclusive environment for all cont
 
 ```bash
 git clone https://github.com/YOUR_USERNAME/sklearn-wrap.git
-cd Sklearn-Wrap
+cd sklearn-wrap
 ```
 
 3. Install dependencies:
@@ -205,7 +205,6 @@ Run tests across multiple Python versions:
     ```bash
     uvx nox -s test
     ```
-
 Run example notebook tests:
 
 === "just"
@@ -227,8 +226,6 @@ Run example notebook tests:
     ```
 
 This runs all notebooks in the `examples/` directory as Python scripts in parallel using pytest-xdist (`-n auto`). Each notebook is executed non-interactively to validate it runs without errors.
-
-
 #### When to Mark Tests as Slow or Integration
 
 Mark your tests appropriately to help maintain fast feedback during development:
@@ -244,13 +241,10 @@ Mark your tests appropriately to help maintain fast feedback during development:
   - Test multiple components working together
   - Require complex setup or teardown
   - Exercise end-to-end workflows
-
 - `@pytest.mark.example` is used in `tests/test_examples.py` to:
   - Validate example notebooks execute without errors
   - Run notebooks in the `examples/` directory
   - Test interactive documentation and tutorials
-
-
 Example:
 
 ```python
@@ -406,28 +400,13 @@ Create a new marimo notebook in `examples/<name>.py`:
    - **Key Takeaways**: Bullet points summarizing important lessons
    - **Next Steps**: Links to related notebooks for progression
    - Isolate utilities and markdown in separate cells
-   - Use `hide_code=True` for infrastructure cells: `import marimo`, pyodide install, library imports, utilities, and markdown cells
-
-   **Pyodide install cell template** (place right after `import marimo as mo`):
-
-   ```python
-   @app.cell(hide_code=True)
-   async def _():
-       import sys
-
-       if "pyodide" in sys.modules:
-           import micropip
-
-           await micropip.install(["scikit-learn"]) # List all packages needed to run the example
-       return
-   ```
+   - Use `hide_code=True` for infrastructure cells: `import marimo`, library imports, utilities, and markdown cells
 
    **`hide_code=True` guidance:** mark these cells as hidden:
 
    | Cell type | Why hidden |
    |-----------|-----------|
    | `import marimo as mo` | Boilerplate, not instructive |
-   | Pyodide install | Infrastructure, not tutorial content |
    | Library imports | Setup, readers focus on usage |
    | Utilities | Not the lesson |
    | Markdown cells | Purely structural |
@@ -469,10 +448,31 @@ Basic familiarity with sklearn's fit/predict API and time series concepts (trend
 
 #### Marimo Cell Conventions
 
+- Add [PEP 723](https://peps.python.org/pep-0723/) inline script metadata at the top of each notebook listing its dependencies
 - Use `hide_code=True` on all markdown cells, import cells, and utility/helper cells
 - Use `r"""..."""` (raw triple-quoted strings) for markdown cell content
-- The second cell (after `import marimo as mo`) must be the Pyodide/micropip guard for browser compatibility
-- Group all imports into a single hidden cell after the Pyodide guard
+- Group all imports into a single hidden cell
+
+**PEP 723 header template** (place at the very top of the file, before `import marimo`):
+
+```python
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "my-dependency",
+# ]
+# ///
+```
+
+**What to include in `dependencies`:**
+
+- Only list packages the notebook **directly imports** (e.g., `numpy`, `plotly`)
+- Include `sklearn_wrap` when the notebook imports from the project itself
+- Do **not** include `marimo` — it is the runner, not a dependency of the script
+- Do **not** include transitive dependencies (packages already pulled in by a listed dependency)
+- Do **not** add `[tool.uv.sources]` — local development uses workspace resolution automatically; published notebooks should resolve from PyPI
+
+When in doubt, run `uv run --script examples/<name>.py` in a clean environment. If it fails with an `ImportError`, add the missing package.
 
 #### Content Guidelines
 
@@ -510,7 +510,6 @@ Add a link to your example in `docs/pages/examples.md`:
 ```
 
 The mkdocs hooks automatically export notebooks to HTML during docs build. All notebooks in `examples/` are automatically discovered and tested by `test_examples.py` using pytest's parametrization feature, which runs them in parallel for fast validation.
-
 ## Submitting Changes
 
 1. Push your changes to your fork:
@@ -579,8 +578,8 @@ graph LR
     G --> H[Create GitHub<br/>Release]
     H --> I{Manual<br/>Approval}
     I -->|Approve| J[Publish to PyPI]
-    style I fill:#b91c1c,stroke:#333,stroke-width:2px,color:#fff
-    style J fill:#16a34a,stroke:#333,stroke-width:2px,color:#fff
+    style I fill:#f59e0b,stroke:#333,stroke-width:2px,color:#fff
+    style J fill:#10b981,stroke:#333,stroke-width:2px,color:#fff
 ```
 
 ### How It Works

--- a/docs/pages/examples.md
+++ b/docs/pages/examples.md
@@ -4,19 +4,19 @@ Learn Sklearn-Wrap through focused, interactive examples. Each notebook demonstr
 
 ## Fundamentals
 
-### A First Wrapper ([View](/examples/first_wrapper/) | [Editable](/examples/first_wrapper/edit/))
+### A First Wrapper ([View](/examples/first_wrapper/) | [Open in marimo](/examples/first_wrapper/edit/))
 
 **Creating Your First Sklearn-Compatible Wrapper**
 
 Start here to understand the fundamental wrapper pattern. This example walks through wrapping a custom polynomial regression algorithm that uses gradient descent. You'll learn the three essential components every wrapper needs: the `_estimator_name` and `_estimator_base_class` attributes, plus the `@_fit_context` decorator. By the end, you'll have a working wrapper that integrates seamlessly with Scikit-Learn's ecosystem.
 
-### Parameter Interface ([View](/examples/parameter_interface/) | [Editable](/examples/parameter_interface/edit/))
+### Parameter Interface ([View](/examples/parameter_interface/) | [Open in marimo](/examples/parameter_interface/edit/))
 
 **Mastering the Parameter Interface**
 
 Dive deep into how `get_params()` and `set_params()` work under the hood. This example demonstrates why Scikit-Learn needs this interface for GridSearchCV and Pipeline, and shows exactly what happens when you change parameters on a fitted estimator. You'll see interactive demos of parameter inspection and modification, plus understand the distinction between wrapper parameters and wrapped class parameters. Essential for working with Scikit-Learn's hyperparameter tuning tools.
 
-### Validation ([View](/examples/validation/) | [Editable](/examples/validation/edit/))
+### Validation ([View](/examples/validation/) | [Open in marimo](/examples/validation/edit/))
 
 **Error Patterns and Parameter Validation**
 
@@ -24,13 +24,13 @@ Learn to handle errors gracefully by exploring five common validation scenarios:
 
 ## Integration with Scikit-Learn
 
-### Grid Search ([View](/examples/grid_search/) | [Editable](/examples/grid_search/edit/))
+### Grid Search ([View](/examples/grid_search/) | [Open in marimo](/examples/grid_search/edit/))
 
 **Hyperparameter Tuning with GridSearchCV**
 
 Apply what you've learned to real hyperparameter optimization. This example wraps a k-nearest neighbors classifier and uses GridSearchCV to find optimal `n_neighbors` and `weights` values through cross-validation. You'll see how Scikit-Learn's parameter interface enables automatic tuning without any special code in your wrapper. Includes interactive parameter exploration and visual comparison of grid search results versus default parameters.
 
-### Nested Wrappers ([View](/examples/nested_wrappers/) | [Editable](/examples/nested_wrappers/edit/))
+### Nested Wrappers ([View](/examples/nested_wrappers/) | [Open in marimo](/examples/nested_wrappers/edit/))
 
 **Controlling Nested Estimator Hierarchies**
 
@@ -38,19 +38,19 @@ Master Scikit-Learn's double-underscore syntax for nested parameters. This examp
 
 ## Advanced Topics
 
-### XGBoost Wrapper ([View](/examples/xgboost_wrapper/) | [Editable](/examples/xgboost_wrapper/edit/))
+### XGBoost Wrapper ([View](/examples/xgboost_wrapper/) | [Open in marimo](/examples/xgboost_wrapper/edit/))
 
 **Wrapping XGBoost's Booster API**
 
 Integrate third-party libraries by wrapping XGBoost's low-level training API. Unlike XGBoost's built-in Scikit-Learn wrappers (XGBRegressor/XGBClassifier), the Booster API offers finer control over the training process. This example shows how to handle library-specific quirks like DMatrix conversion and parameter formatting. Demonstrates that Sklearn-Wrap isn't just for custom code, it's equally valuable for bringing external libraries into Scikit-Learn's ecosystem.
 
-### Serialization ([View](/examples/serialization/) | [Editable](/examples/serialization/edit/))
+### Serialization ([View](/examples/serialization/) | [Open in marimo](/examples/serialization/edit/))
 
 **Persistence with Joblib**
 
 Save and load your wrapped estimators for production deployment. This example covers three serialization scenarios: standalone wrapped estimators, complete pipelines combining wrappers with Scikit-Learn transformers, and full GridSearchCV objects including all cross-validation results. You'll verify that deserialized objects maintain identical behavior to their originals, which is critical for reproducible ML workflows and model deployment.
 
-### Fit Context ([View](/examples/fit_context/) | [Editable](/examples/fit_context/edit/))
+### Fit Context ([View](/examples/fit_context/) | [Open in marimo](/examples/fit_context/edit/))
 
 **Understanding the _fit_context Decorator**
 

--- a/examples/first_wrapper.py
+++ b/examples/first_wrapper.py
@@ -1,3 +1,12 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "numpy",
+#     "plotly",
+#     "scikit-learn",
+#     "sklearn-wrap",
+# ]
+# ///
 """
 # Your First Wrapper
 
@@ -9,17 +18,6 @@ import marimo
 
 __generated_with = "0.19.8"
 app = marimo.App(width="medium")
-
-
-@app.cell(hide_code=True)
-async def _():
-    import sys
-
-    if "pyodide" in sys.modules:
-        import micropip
-
-        await micropip.install(["numpy", "plotly", "scikit-learn", "sklearn-wrap"])
-    return
 
 
 @app.cell(hide_code=True)

--- a/examples/fit_context.py
+++ b/examples/fit_context.py
@@ -1,3 +1,11 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "numpy",
+#     "scikit-learn",
+#     "sklearn-wrap",
+# ]
+# ///
 """
 # Fit Context Decorator
 
@@ -8,17 +16,6 @@ import marimo
 
 __generated_with = "0.19.8"
 app = marimo.App(width="medium")
-
-
-@app.cell(hide_code=True)
-async def _():
-    import sys
-
-    if "pyodide" in sys.modules:
-        import micropip
-
-        await micropip.install(["numpy", "scikit-learn", "sklearn-wrap"])
-    return
 
 
 @app.cell(hide_code=True)

--- a/examples/grid_search.py
+++ b/examples/grid_search.py
@@ -1,3 +1,12 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "numpy",
+#     "plotly",
+#     "scikit-learn",
+#     "sklearn-wrap",
+# ]
+# ///
 """
 # GridSearch with Wrappers
 
@@ -8,17 +17,6 @@ import marimo
 
 __generated_with = "0.19.8"
 app = marimo.App(width="medium")
-
-
-@app.cell(hide_code=True)
-async def _():
-    import sys
-
-    if "pyodide" in sys.modules:
-        import micropip
-
-        await micropip.install(["numpy", "plotly", "scikit-learn", "sklearn-wrap"])
-    return
 
 
 @app.cell(hide_code=True)

--- a/examples/nested_wrappers.py
+++ b/examples/nested_wrappers.py
@@ -1,3 +1,12 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "numpy",
+#     "plotly",
+#     "scikit-learn",
+#     "sklearn-wrap",
+# ]
+# ///
 """
 # Nested Parameters
 
@@ -8,17 +17,6 @@ import marimo
 
 __generated_with = "0.19.8"
 app = marimo.App(width="medium")
-
-
-@app.cell(hide_code=True)
-async def _():
-    import sys
-
-    if "pyodide" in sys.modules:
-        import micropip
-
-        await micropip.install(["numpy", "plotly", "scikit-learn", "sklearn-wrap"])
-    return
 
 
 @app.cell(hide_code=True)

--- a/examples/parameter_interface.py
+++ b/examples/parameter_interface.py
@@ -1,3 +1,12 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "numpy",
+#     "plotly",
+#     "scikit-learn",
+#     "sklearn-wrap",
+# ]
+# ///
 """
 # Parameter Management
 
@@ -9,17 +18,6 @@ import marimo
 
 __generated_with = "0.19.8"
 app = marimo.App(width="medium")
-
-
-@app.cell(hide_code=True)
-async def _():
-    import sys
-
-    if "pyodide" in sys.modules:
-        import micropip
-
-        await micropip.install(["numpy", "plotly", "scikit-learn", "sklearn-wrap"])
-    return
 
 
 @app.cell(hide_code=True)

--- a/examples/serialization.py
+++ b/examples/serialization.py
@@ -1,3 +1,11 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "numpy",
+#     "scikit-learn",
+#     "sklearn-wrap",
+# ]
+# ///
 """
 # Serialization and Persistence
 
@@ -9,17 +17,6 @@ import marimo
 
 __generated_with = "0.19.8"
 app = marimo.App(width="medium")
-
-
-@app.cell(hide_code=True)
-async def _():
-    import sys
-
-    if "pyodide" in sys.modules:
-        import micropip
-
-        await micropip.install(["numpy", "scikit-learn", "sklearn-wrap"])
-    return
 
 
 @app.cell(hide_code=True)

--- a/examples/validation.py
+++ b/examples/validation.py
@@ -1,3 +1,11 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "numpy",
+#     "scikit-learn",
+#     "sklearn-wrap",
+# ]
+# ///
 """
 # Validation and Error Handling
 
@@ -8,17 +16,6 @@ import marimo
 
 __generated_with = "0.19.8"
 app = marimo.App(width="medium")
-
-
-@app.cell(hide_code=True)
-async def _():
-    import sys
-
-    if "pyodide" in sys.modules:
-        import micropip
-
-        await micropip.install(["numpy", "scikit-learn", "sklearn-wrap"])
-    return
 
 
 @app.cell(hide_code=True)

--- a/examples/xgboost_wrapper.py
+++ b/examples/xgboost_wrapper.py
@@ -1,3 +1,12 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "numpy",
+#     "scikit-learn",
+#     "sklearn-wrap",
+#     "xgboost",
+# ]
+# ///
 """
 # XGBoost Integration
 
@@ -8,17 +17,6 @@ import marimo
 
 __generated_with = "0.19.8"
 app = marimo.App(width="medium")
-
-
-@app.cell(hide_code=True)
-async def _():
-    import sys
-
-    if "pyodide" in sys.modules:
-        import micropip
-
-        await micropip.install(["numpy", "xgboost", "scikit-learn", "sklearn-wrap"])
-    return
 
 
 @app.cell(hide_code=True)

--- a/noxfile.py
+++ b/noxfile.py
@@ -243,6 +243,8 @@ def build_docs(session: nox.Session) -> None:
         "--no-default-groups",
         "--group",
         "docs",
+        "--group",
+        "examples",
         env={"UV_PROJECT_ENVIRONMENT": session.virtualenv.location},
     )
 
@@ -260,6 +262,8 @@ def serve_docs(session: nox.Session) -> None:
         "--no-default-groups",
         "--group",
         "docs",
+        "--group",
+        "examples",
         env={"UV_PROJECT_ENVIRONMENT": session.virtualenv.location},
     )
 


### PR DESCRIPTION
Update from template v0.14.0 (`uvx copier update`).

## Changes

- Replace WASM export with marimo.app playground URLs in `docs/hooks.py`
- Add PEP 723 inline script metadata to all example notebooks
- Remove pyodide/micropip cells from notebooks (no longer needed)
- Update contributing guide with PEP 723 dependency conventions
- Change `[Editable]` links to `[Open in marimo]` in `docs/pages/examples.md`
- Install `examples` group in `build_docs`/`serve_docs` nox sessions