### PR TITLE
fix(examples): avoid marimo name mangling of _fit_context

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ This project is licensed under the terms of the [Apache-2.0 License](https://git
 
 ## Acknowledgements
 
-This project is maintained by [stateful-y](https://stateful-y.io), an ML consultancy specializing in MLOps and data science & engineering. If you're interested in collaborating or learning more about our services, please visit our website.
+This project is maintained by [stateful-y](https://stateful-y.io), an ML consultancy specializing in data science & engineering. If you're interested in collaborating or learning more about our services, please visit our website.
 
 <p align="center">
   <a href="https://stateful-y.io">

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,4 +45,14 @@ With Sklearn-Wrap, you gain immediate access to GridSearchCV for hyperparameter 
 
 ## License
 
-Sklearn-Wrap is open source and licensed under the [Apache-2.0 License](https://opensource.org/licenses/Apache-2.0). You are free to use, modify, and distribute this software under the terms of this license.
+This project is licensed under the terms of the [Apache-2.0 License](https://github.com/stateful-y/sklearn-wrap/blob/main/LICENSE).
+
+## Acknowledgements
+
+This project is maintained by [stateful-y](https://stateful-y.io), an ML consultancy specializing in data science & engineering. If you're interested in collaborating or learning more about our services, please visit our website.
+
+<p align="center">
+  <a href="https://stateful-y.io">
+    <img src="docs/assets/made_by_stateful-y.png" alt="Made by stateful-y" width="200">
+  </a>
+</p>

--- a/docs/index.md
+++ b/docs/index.md
@@ -53,6 +53,6 @@ This project is maintained by [stateful-y](https://stateful-y.io), an ML consult
 
 <p align="center">
   <a href="https://stateful-y.io">
-    <img src="docs/assets/made_by_stateful-y.png" alt="Made by stateful-y" width="200">
+    <img src="assets/made_by_stateful-y.png" alt="Made by stateful-y" width="200">
   </a>
 </p>

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,8 +51,4 @@ This project is licensed under the terms of the [Apache-2.0 License](https://git
 
 This project is maintained by [stateful-y](https://stateful-y.io), an ML consultancy specializing in data science & engineering. If you're interested in collaborating or learning more about our services, please visit our website.
 
-<p align="center">
-  <a href="https://stateful-y.io">
-    <img src="assets/made_by_stateful-y.png" alt="Made by stateful-y" width="200">
-  </a>
-</p>
+![Made by stateful-y](assets/made_by_stateful-y.png){width=200}

--- a/examples/fit_context.py
+++ b/examples/fit_context.py
@@ -36,8 +36,8 @@ def _():
     import numpy as np
 
     from sklearn_wrap import BaseClassWrapper
-    from sklearn_wrap.base import _fit_context
-    return BaseClassWrapper, np, _fit_context
+    from sklearn_wrap import base as skw_base
+    return BaseClassWrapper, np, skw_base
 
 
 @app.cell(hide_code=True)
@@ -131,12 +131,12 @@ def _(mo):
 
 
 @app.cell
-def _(BaseClassWrapper, _fit_context):
+def _(BaseClassWrapper, skw_base):
     class DecoratorWrapper(BaseClassWrapper):
         _estimator_name = "model"
         _estimator_base_class = object
 
-        @_fit_context(prefer_skip_nested_validation=True)
+        @skw_base._fit_context(prefer_skip_nested_validation=True)
         def fit(self, X, y):
             # instantiate() called automatically by decorator
             self.instance_.train_model(X, y)
@@ -226,7 +226,7 @@ def _(mo):
 
 
 @app.cell
-def _(BaseClassWrapper, np, _fit_context):
+def _(BaseClassWrapper, np, skw_base):
     class IncrementalModel:
         def __init__(self):
             self.sum_ = 0.0
@@ -244,7 +244,7 @@ def _(BaseClassWrapper, np, _fit_context):
         _estimator_name = "model"
         _estimator_base_class = object
 
-        @_fit_context(prefer_skip_nested_validation=True)
+        @skw_base._fit_context(prefer_skip_nested_validation=True)
         def partial_fit(self, X, y):
             self.instance_.partial_fit(X, y)
             return self

--- a/examples/xgboost_wrapper.py
+++ b/examples/xgboost_wrapper.py
@@ -64,7 +64,7 @@ def _(mo):
 
 @app.cell
 def _(BaseClassWrapper, xgb):
-    from sklearn_wrap.base import _fit_context
+    from sklearn_wrap import base as skw_base
 
     class XGBoostCallbackWrapper(BaseClassWrapper):
         """Wrap XGBoost callback classes.
@@ -134,7 +134,7 @@ def _(BaseClassWrapper, xgb):
             "callbacks": [None, {"wrapper_base_class": xgb.callback.TrainingCallback}]
         }
 
-        @_fit_context(prefer_skip_nested_validation=True)
+        @skw_base._fit_context(prefer_skip_nested_validation=True)
         def fit(self, X, y):
             self.instance_.fit_model(X, y)
             return self


### PR DESCRIPTION
## Description

Fix `NameError` in `fit_context.py` and `xgboost_wrapper.py` marimo notebooks caused by marimo's cell-private name mangling of underscore-prefixed variables.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

Marimo treats `_`-prefixed local variable names as cell-private and mangles them (e.g. `_fit_context` becomes `_cell_BYtC_fit_context`), causing `NameError` when accessed across cells. This breaks CI on all PRs (including dependabot).

The fix uses module attribute access (`skw_base._fit_context`) instead of importing the name directly, which avoids mangling while keeping the real API name visible at the usage site.

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just fix` to format my code
- [x] All new and existing tests passed