### PR TITLE
Add FunctionWrapper for wrapping callables into sklearn-compatible functors

### DIFF
--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -1027,7 +1027,6 @@ def on_pre_build(config):
                     "-m",
                     "marimo",
                     "-y",
-                    "-q",
                     "export",
                     "html",
                     "--no-sandbox",
@@ -1043,6 +1042,8 @@ def on_pre_build(config):
         except subprocess.CalledProcessError as e:
             failed.append(str(rel_path))
             print(f"[hooks] FAILED html {rel_path}: {e}", file=sys.stderr)
+            if e.stdout:
+                print(e.stdout, file=sys.stderr)
             if e.stderr:
                 print(e.stderr, file=sys.stderr)
             continue

--- a/docs/pages/explanation/function-wrapping.md
+++ b/docs/pages/explanation/function-wrapping.md
@@ -1,0 +1,96 @@
+# About Function Wrapping
+
+Sklearn-Wrap provides two complementary approaches for integrating custom code with scikit-learn's ecosystem: `BaseClassWrapper` for wrapping classes, and `FunctionWrapper` for wrapping standalone callables. This page explains the functor design behind `FunctionWrapper`, the conventions it follows, and how it relates to its class-wrapping sibling.
+
+## The Functor Approach
+
+A functor is an object that can be called like a function but also carries state. `FunctionWrapper` turns any Python callable into a functor whose configuration is managed through scikit-learn's `get_params`/`set_params` protocol.
+
+This is useful when you have a function (not a class) whose behavior you want to tune, compose in pipelines, or search over with `GridSearchCV`. Rather than manually threading configuration through function arguments, the wrapper stores config params and injects them at call time.
+
+The core interaction is simple: positional arguments at the call site are data, stored keyword-only parameters are config.
+
+```python
+# Without a wrapper: config mixed with data at every call site
+result = predict(X, scale=2.0, offset=1.0)
+
+# With a wrapper: config stored once, data passed at call time
+predictor = ScaledPredictor(fn=predict, scale=2.0, offset=1.0)
+result = predictor(X)
+```
+
+## The Keyword-Only Convention
+
+`FunctionWrapper` needs a way to distinguish data parameters (passed at call time) from config parameters (stored on the wrapper). It uses Python's keyword-only parameter syntax as the dividing line.
+
+In a function signature, everything before the `*` separator is positional (data). Everything after is keyword-only (config):
+
+```python
+def my_function(X, y, *, alpha=1.0, beta=2.0):
+    #             ↑ data    ↑ config
+    ...
+```
+
+This convention was chosen because it aligns with how Python already distinguishes parameter kinds, requires no metadata or decorators, and makes the separation visible in the function signature itself. Functions that follow this convention work with `FunctionWrapper` without modification.
+
+When `FunctionWrapper` inspects a callable's signature, it extracts only `KEYWORD_ONLY` parameters. `POSITIONAL_ONLY`, `POSITIONAL_OR_KEYWORD`, and `VAR_POSITIONAL` parameters are ignored entirely, since they represent data that flows through `__call__`.
+
+If the function accepts `**kwargs`, the wrapper allows arbitrary extra config parameters beyond the declared keyword-only ones. This is useful for functions that forward configuration to underlying systems.
+
+## Relationship to BaseClassWrapper
+
+`FunctionWrapper` and `BaseClassWrapper` are independent siblings, both inheriting from scikit-learn's `BaseEstimator`. They share the same parameter management philosophy but differ in their lifecycle:
+
+| Aspect | BaseClassWrapper | FunctionWrapper |
+|--------|-----------------|-----------------|
+| Wraps | A class | A callable |
+| Lifecycle | Creates `self.instance_` on fit | No instance lifecycle |
+| Config stored as | `self.params` | `self._params` |
+| Delegation | `self.instance_.method(...)` | `self.callable_fn(*args, **self._params)` |
+| Call convention | Not callable | Callable via `__call__` |
+
+`BaseClassWrapper` manages a three-phase lifecycle (configuration, instantiation, delegation) because it wraps classes that need to be constructed, fitted, and queried. `FunctionWrapper` is simpler: the callable exists at construction time and is invoked directly. There is no instance to create or destroy.
+
+Both wrappers can be extended into full sklearn estimators by adding mixins (`RegressorMixin`, `ClassifierMixin`) and implementing `fit`/`predict`/`transform`. The `_fit_context` decorator works identically with both.
+
+## Internal Parameter Storage
+
+`FunctionWrapper` stores config parameters in `self._params` (with an underscore prefix) rather than `self.params`. This is a deliberate choice to avoid a `RecursionError` in scikit-learn's `BaseEstimator.__repr__`.
+
+The issue: sklearn's repr system introspects the `__init__` signature to detect changed parameters. Since `FunctionWrapper.__init__` accepts `**params`, sklearn cannot determine individual parameter defaults and falls back to inspecting instance attributes. A public `self.params` dict attribute triggers a repr cycle where sklearn tries to display the dict, encounters the estimator again, and recurses.
+
+`BaseClassWrapper` avoids this because its `__init__` has explicit attribute access patterns that sklearn's repr can resolve. `FunctionWrapper` with `__init__(**params)` does not have those, so the underscore prefix hides the dict from sklearn's introspection.
+
+## The `instantiate()` Step
+
+Both wrappers provide an `instantiate()` method, but they do different things:
+
+- **BaseClassWrapper**: validates parameters, creates `self.instance_ = estimator_class(**params)`, and resets the fitted flag.
+- **FunctionWrapper**: validates parameters and checks for required sentinels. No instance is created, and the fitted flag is not touched.
+
+`FunctionWrapper.instantiate()` is called automatically by `__call__` (before invoking the callable) and by `_fit_context` (before running `fit`). It acts as a validation gate, ensuring that all required parameters have been provided before the callable is invoked.
+
+## Extending to a Full Estimator
+
+`FunctionWrapper` on its own is a parameter-managed functor. To turn it into a proper scikit-learn estimator, subclass it with a mixin and implement the estimator interface:
+
+```python
+class FunctionRegressor(FunctionWrapper, RegressorMixin):
+    _callable_name = "fn"
+
+    @_fit_context(prefer_skip_nested_validation=True)
+    def fit(self, X, y=None):
+        self.n_features_in_ = np.asarray(X).shape[1]
+        return self
+
+    def predict(self, X):
+        return self.callable_fn(np.asarray(X), **self._params)
+```
+
+The `_fit_context` decorator is reused without modification. It checks for the presence of `instantiate()` on the estimator and calls it before fit, regardless of whether the estimator wraps a class or a function.
+
+## Serialization Considerations
+
+Named functions defined at module level serialize correctly with `pickle` and `joblib`, since Python serializes them by reference (module path + function name). Lambdas and closures cannot be serialized this way, because they lack a stable qualified name. If you need to save and load a `FunctionWrapper`, use named functions.
+
+`functools.partial` objects work correctly with `FunctionWrapper` (the signature is resolved through the partial), but they are deep-copied during `clone()` rather than preserved by reference. This means identity checks like `cloned.callable_fn is original_partial` will fail, but behavioral equivalence is maintained.

--- a/docs/pages/explanation/index.md
+++ b/docs/pages/explanation/index.md
@@ -6,5 +6,6 @@ Background on design decisions, architecture, and the concepts behind Sklearn-Wr
 |---------|-------------|
 | [The Delegation Pattern](delegation-pattern.md) | Composition over inheritance, the three-phase lifecycle, and nested parameter syntax |
 | [The Fit Context Lifecycle](fit-context-lifecycle.md) | How `_fit_context` automates instantiation, validation, and context management |
+| [Function Wrapping](function-wrapping.md) | The functor design, keyword-only convention, and relationship to `BaseClassWrapper` |
 | [Trade-offs and Limitations](trade-offs.md) | Immutability, validation overhead, metadata routing, and proxy boundaries |
 | [YAML Configuration Design](yaml-config-design.md) | Why declarative config, the trusted modules security model, and `!include` composition |

--- a/docs/pages/how-to/index.md
+++ b/docs/pages/how-to/index.md
@@ -5,6 +5,7 @@ Task-oriented guides for common Sklearn-Wrap workflows. Each guide addresses a s
 | Guide | Description |
 |-------|-------------|
 | [Wrap a Class](wrap-a-class.md) | Turn any Python class into an sklearn estimator |
+| [Wrap Functions](wrap-functions.md) | Turn standalone functions into sklearn-compatible functors |
 | [Validate Parameters](validate-parameters.md) | Add type and value constraints to wrapper parameters |
 | [Use YAML Configuration](yaml-configuration.md) | Build, save, and load estimators from YAML files |
 | [Use with GridSearchCV](use-with-gridsearch.md) | Run hyperparameter search on wrapped estimators |

--- a/docs/pages/how-to/wrap-functions.md
+++ b/docs/pages/how-to/wrap-functions.md
@@ -1,0 +1,162 @@
+# How to Wrap Functions
+
+This guide shows you how to wrap standalone Python functions into scikit-learn compatible functors. Use this when you have a function whose configuration you want to manage via `get_params`/`set_params`, tune with `GridSearchCV`, or compose in a `Pipeline`.
+
+!!! tip "Interactive notebook available"
+
+    Try this guide as an interactive notebook:
+    [Function Wrapper](/examples/function_wrapper/)
+
+## Prerequisites
+
+- sklearn-wrap installed ([Getting Started](../tutorials/getting-started.md))
+- Familiarity with scikit-learn's `fit`/`predict` pattern
+
+## Wrapping a Basic Function
+
+### 1. Define a Function with the Keyword-Only Convention
+
+Separate data parameters (positional) from config parameters (keyword-only, after `*`):
+
+```python
+def predict(X, *, scale=1.0, offset=0.0):
+    return X.sum(axis=1) * scale + offset
+```
+
+### 2. Create a Wrapper Subclass
+
+```python
+from sklearn_wrap import FunctionWrapper
+
+class MyPredictor(FunctionWrapper):
+    _callable_name = "fn"
+```
+
+### 3. Instantiate and Call
+
+```python
+wrapper = MyPredictor(fn=predict, scale=2.0)
+result = wrapper(X)  # positional data args forwarded, config injected
+```
+
+## Providing a Default Callable
+
+If your wrapper always uses the same function, set `_callable_default` so users don't need to pass it:
+
+```python
+class MyPredictor(FunctionWrapper):
+    _callable_name = "fn"
+    _callable_default = predict
+```
+
+```python
+# No need to pass fn=
+wrapper = MyPredictor(scale=3.0)
+```
+
+## Functions with `**kwargs`
+
+If the wrapped function accepts `**kwargs`, the wrapper allows arbitrary extra config parameters:
+
+```python
+def flexible_predict(X, *, base=1.0, **extra):
+    return X * base + sum(extra.values())
+
+wrapper = MyPredictor(fn=flexible_predict, base=2.0, bonus=5.0, penalty=1.0)
+```
+
+All extra keyword arguments are stored and managed via `get_params`/`set_params`.
+
+## Using `functools.partial`
+
+`FunctionWrapper` works with `functools.partial`. The signature is resolved through the partial, preserving keyword-only params with updated defaults:
+
+```python
+import functools
+
+base_fn = lambda X, y, *, alpha=1.0, beta=2.0: X * alpha + beta
+
+tuned_fn = functools.partial(base_fn, beta=10.0)
+wrapper = MyPredictor(fn=tuned_fn, alpha=3.0)
+
+# beta defaults to 10.0 (from partial), alpha set to 3.0
+print(wrapper.get_params())
+```
+
+## Building a Full Estimator
+
+To use the wrapper with `Pipeline`, `GridSearchCV`, and `cross_val_score`, add a scikit-learn mixin and implement `fit`/`predict`:
+
+```python
+import numpy as np
+from sklearn.base import RegressorMixin
+from sklearn_wrap.base import _fit_context
+
+class FunctionRegressor(FunctionWrapper, RegressorMixin):
+    _callable_name = "fn"
+
+    @_fit_context(prefer_skip_nested_validation=True)
+    def fit(self, X, y=None):
+        self.n_features_in_ = np.asarray(X).shape[1]
+        return self
+
+    def predict(self, X):
+        X = np.asarray(X)
+        return self.callable_fn(X, **self._params)
+```
+
+The `@_fit_context` decorator handles parameter validation before `fit` runs. After a successful `fit`, the estimator is marked as fitted.
+
+### Using in a Pipeline
+
+```python
+from sklearn.pipeline import Pipeline
+
+pipe = Pipeline([
+    ("regressor", FunctionRegressor(fn=predict, scale=1.0)),
+])
+pipe.fit(X_train, y_train)
+
+# Nested parameter access
+pipe.set_params(regressor__scale=3.0)
+```
+
+### Using with GridSearchCV
+
+```python
+from sklearn.model_selection import GridSearchCV
+
+grid = GridSearchCV(
+    FunctionRegressor(fn=predict),
+    param_grid={"scale": [0.5, 1.0, 2.0], "offset": [0.0, 1.0]},
+    cv=3,
+)
+grid.fit(X_train, y_train)
+```
+
+## Functions with Required Parameters
+
+If a keyword-only parameter has no default, the wrapper marks it as required. You must provide it before calling or fitting:
+
+```python
+def transform(X, *, gamma):
+    return X ** gamma
+
+wrapper = MyPredictor(fn=transform)
+# wrapper(X)  # raises ValueError: requires parameter 'gamma'
+
+wrapper = MyPredictor(fn=transform, gamma=2.0)
+wrapper(X)  # works
+```
+
+## Limitations
+
+- **Lambdas and closures** cannot be serialized with `pickle`/`joblib`. If you need serialization, use named functions defined at module level.
+- **Uninspectable callables** (where `inspect.signature` fails) are rejected at construction time. Most modern C extensions ship with `.pyi` stubs that make inspection work, but some built-in functions may not be wrappable.
+
+## See Also
+
+- [Wrapping Functions tutorial](../tutorials/wrapping-functions.md): step-by-step introduction
+- [About Function Wrapping](../explanation/function-wrapping.md): the functor design and its relationship to `BaseClassWrapper`
+- [How to Wrap a Class](wrap-a-class.md): wrapping classes with instance lifecycle management
+- [API Reference](../reference/api.md): full `FunctionWrapper` documentation

--- a/docs/pages/tutorials/index.md
+++ b/docs/pages/tutorials/index.md
@@ -12,6 +12,14 @@ Step-by-step guides to installing and using Sklearn-Wrap in your project.
 
     [Getting Started](getting-started.md)
 
+- **Wrapping Functions**
+
+    ---
+
+    Wrap standalone functions into sklearn-compatible functors. Learn the keyword-only convention, functor calls, and extending to a full estimator.
+
+    [Wrapping Functions](wrapping-functions.md)
+
 - **Examples**
 
     ---

--- a/docs/pages/tutorials/wrapping-functions.md
+++ b/docs/pages/tutorials/wrapping-functions.md
@@ -1,0 +1,158 @@
+# Wrapping Functions
+
+In this tutorial, we will wrap a standalone Python function into a scikit-learn compatible functor using `FunctionWrapper`. Along the way, we will define a wrapper subclass, call it as a functor, and then extend it into a full estimator for use with `GridSearchCV`.
+
+!!! tip "Interactive notebook available"
+
+    Try the concepts from this tutorial as an interactive notebook:
+    [Function Wrapper](/examples/function_wrapper/)
+
+## Prerequisites
+
+- Python 3.11+ installed
+- sklearn-wrap installed ([Getting Started](getting-started.md))
+
+## The Keyword-Only Convention
+
+`FunctionWrapper` identifies config parameters by inspecting your function's signature. Parameters before the `*` separator are **data** (passed at call time), parameters after `*` are **config** (stored on the wrapper and managed via `get_params`/`set_params`).
+
+```python
+def scaled_predict(X, *, scale=1.0, offset=0.0):
+    """Positional args = data, keyword-only args = config."""
+    return X.sum(axis=1) * scale + offset
+```
+
+Here, `X` is data (passed when calling the wrapper), while `scale` and `offset` are config (stored and tunable).
+
+## Creating a Function Wrapper
+
+Now we create a wrapper subclass. The only required attribute is `_callable_name`, which names the keyword argument used to pass the callable:
+
+```python
+from sklearn_wrap import FunctionWrapper
+
+class ScaledPredictor(FunctionWrapper):
+    _callable_name = "fn"
+```
+
+That's it. Let's create an instance and inspect its parameters:
+
+```python
+predictor = ScaledPredictor(fn=scaled_predict, scale=2.0, offset=1.0)
+print(predictor.get_params())
+```
+
+The output should look something like:
+
+```text
+{'scale': 2.0, 'offset': 1.0, 'fn': <function scaled_predict at 0x...>}
+```
+
+Notice that `scale` and `offset` are managed as sklearn parameters, while `fn` holds the wrapped callable.
+
+## Calling the Wrapper
+
+Call the wrapper like a regular function. Positional data arguments are forwarded, and stored config params are injected automatically:
+
+```python
+import numpy as np
+
+X = np.array([[1, 2], [3, 4], [5, 6]])
+result = predictor(X)
+print(result)
+```
+
+The output should look something like:
+
+```text
+[ 7. 15. 23.]
+```
+
+Each prediction is `X.sum(axis=1) * 2.0 + 1.0`. Notice that `scale` and `offset` came from the wrapper's stored config, not from the call site.
+
+## Updating Parameters
+
+Use `set_params` to change config without creating a new wrapper:
+
+```python
+predictor.set_params(scale=0.5, offset=10.0)
+print(predictor(X))
+```
+
+```text
+[11.5 13.5 15.5]
+```
+
+## Cloning
+
+The wrapper works with sklearn's `clone()`, which creates a fresh copy with the same parameters:
+
+```python
+from sklearn.base import clone
+
+cloned = clone(predictor)
+print(cloned.get_params()["scale"])  # 0.5
+print(cloned.callable_fn is scaled_predict)  # True
+```
+
+## Building a Full Estimator
+
+To use the wrapper with `Pipeline` and `GridSearchCV`, add a sklearn mixin and implement `fit`/`predict`. Use the `@_fit_context` decorator for automatic validation:
+
+```python
+from sklearn.base import RegressorMixin
+from sklearn_wrap.base import _fit_context
+
+class FunctionRegressor(FunctionWrapper, RegressorMixin):
+    _callable_name = "fn"
+
+    @_fit_context(prefer_skip_nested_validation=True)
+    def fit(self, X, y=None):
+        self.n_features_in_ = np.asarray(X).shape[1]
+        return self
+
+    def predict(self, X):
+        X = np.asarray(X)
+        return self.callable_fn(X, **self._params)
+```
+
+Now let's use it with `GridSearchCV`:
+
+```python
+from sklearn.model_selection import GridSearchCV
+
+X_train = np.random.randn(100, 3)
+y_train = X_train.sum(axis=1) * 2.0 + 1.0
+
+grid = GridSearchCV(
+    FunctionRegressor(fn=scaled_predict),
+    param_grid={"scale": [0.5, 1.0, 2.0, 3.0], "offset": [0.0, 0.5, 1.0]},
+    cv=3,
+    scoring="neg_mean_squared_error",
+)
+grid.fit(X_train, y_train)
+print(f"Best params: {grid.best_params_}")
+```
+
+You should see output like:
+
+```text
+Best params: {'offset': 1.0, 'scale': 2.0}
+```
+
+The exact values may vary, but notice that `GridSearchCV` found the optimal `scale` and `offset` automatically.
+
+## What We Built
+
+We wrapped a standalone function into an sklearn-compatible functor using `FunctionWrapper`. Along the way, we:
+
+- Used the keyword-only convention to separate data from config parameters
+- Created a wrapper subclass with a single `_callable_name` attribute
+- Called the wrapper as a functor and updated its parameters
+- Extended it into a full estimator with `RegressorMixin` and `_fit_context`
+
+**Next steps:**
+
+- [How to Wrap Functions](../how-to/wrap-functions.md): task-oriented guide covering `functools.partial`, `**kwargs`, and advanced patterns
+- [About Function Wrapping](../explanation/function-wrapping.md): the functor design and how it relates to `BaseClassWrapper`
+- [API Reference](../reference/api.md): full `FunctionWrapper` documentation

--- a/examples/function_wrapper.py
+++ b/examples/function_wrapper.py
@@ -1,0 +1,267 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "numpy",
+#     "scikit-learn",
+#     "sklearn-wrap",
+# ]
+# ///
+"""
+# Function Wrapper
+
+In this notebook, we wrap standalone functions into scikit-learn compatible
+functors using FunctionWrapper.
+"""
+
+import marimo
+
+__generated_with = "0.19.8"
+__gallery__ = {
+    "title": "Function Wrapper",
+    "description": "Wrap standalone functions into sklearn-compatible functors with get_params/set_params using FunctionWrapper.",
+    "category": "tutorial",
+    "companion": "pages/tutorials/wrapping-functions.md",
+}
+app = marimo.App(width="medium")
+
+
+@app.cell(hide_code=True)
+def _():
+    import marimo as mo
+    return (mo,)
+
+
+@app.cell(hide_code=True)
+def _():
+    import numpy as np
+    from sklearn.base import RegressorMixin, clone
+    from sklearn.model_selection import GridSearchCV, cross_val_score
+    from sklearn.pipeline import Pipeline
+
+    from sklearn_wrap import FunctionWrapper
+    from sklearn_wrap.base import _fit_context
+
+    return (
+        FunctionWrapper,
+        GridSearchCV,
+        Pipeline,
+        RegressorMixin,
+        _fit_context,
+        clone,
+        cross_val_score,
+        np,
+    )
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md("""
+    In this notebook, we wrap standalone functions into scikit-learn compatible
+    functors using `FunctionWrapper`. The key convention: positional parameters
+    are data (passed at call time), keyword-only parameters (after `*`) are
+    config (stored on the wrapper and managed via `get_params`/`set_params`).
+
+    **Prerequisites:** Basic familiarity with scikit-learn estimators.
+    """)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md("""
+    ## 1. The Keyword-Only Convention
+
+    `FunctionWrapper` identifies config parameters by looking at keyword-only
+    arguments in your function signature. Everything before `*` is data,
+    everything after is config.
+    """)
+    return
+
+
+@app.cell
+def _():
+    def scaled_predict(X, *, scale=1.0, offset=0.0):
+        """Positional args = data, keyword-only args = config."""
+        return X.sum(axis=1) * scale + offset
+
+    return (scaled_predict,)
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md("""
+    ## 2. Basic Functor Usage
+
+    Create a `FunctionWrapper` subclass by setting `_callable_name`. The wrapper
+    automatically extracts keyword-only parameters and manages them via
+    `get_params`/`set_params`.
+    """)
+    return
+
+
+@app.cell
+def _(FunctionWrapper):
+    class ScaledPredictor(FunctionWrapper):
+        _callable_name = "fn"
+
+    return (ScaledPredictor,)
+
+
+@app.cell
+def _(ScaledPredictor, mo, scaled_predict):
+    # Create a wrapper with custom config
+    predictor = ScaledPredictor(fn=scaled_predict, scale=2.0, offset=1.0)
+
+    # Inspect managed parameters
+    mo.md(f"**Parameters:** `{predictor.get_params()}`")
+    return (predictor,)
+
+
+@app.cell
+def _(mo, np, predictor):
+    # Call it like a function: data goes in as positional args
+    X_demo = np.array([[1, 2], [3, 4], [5, 6]])
+    result = predictor(X_demo)
+    mo.md(f"**Predictions:** `{result}`  (scale=2.0, offset=1.0)")
+    return (X_demo,)
+
+
+@app.cell
+def _(clone, mo, predictor):
+    # Clone preserves callable identity and config
+    cloned = clone(predictor)
+    mo.md(f"**Cloned params:** `{cloned.get_params()}`")
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md("""
+    ## 3. Full Estimator with Mixins
+
+    By adding `RegressorMixin` and implementing `fit`/`predict` with
+    `_fit_context`, you get a proper sklearn estimator that works in
+    `Pipeline`, `GridSearchCV`, and `cross_val_score`.
+    """)
+    return
+
+
+@app.cell
+def _(FunctionWrapper, RegressorMixin, _fit_context, np):
+    class FunctionRegressor(FunctionWrapper, RegressorMixin):
+        _callable_name = "fn"
+
+        @_fit_context(prefer_skip_nested_validation=True)
+        def fit(self, X, y=None):
+            self.n_features_in_ = np.asarray(X).shape[1]
+            return self
+
+        def predict(self, X):
+            X = np.asarray(X)
+            return self.callable_fn(X, **self._params)
+
+    return (FunctionRegressor,)
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md("""
+    ## 4. Pipeline and GridSearchCV
+
+    The wrapper integrates seamlessly with sklearn's pipeline and
+    hyperparameter search tools.
+    """)
+    return
+
+
+@app.cell
+def _(np):
+    # Generate sample data
+    rng = np.random.RandomState(42)
+    X_train = rng.randn(100, 3)
+    y_train = X_train.sum(axis=1) * 2.0 + 1.0 + rng.randn(100) * 0.1
+    return X_train, y_train
+
+
+@app.cell
+def _(FunctionRegressor, Pipeline, X_train, mo, scaled_predict, y_train):
+    # Use in a Pipeline
+    pipe = Pipeline([
+        ("regressor", FunctionRegressor(fn=scaled_predict, scale=1.0)),
+    ])
+    pipe.fit(X_train, y_train)
+
+    # Nested parameter access works
+    mo.md(f"**Pipeline params:** scale={pipe.get_params()['regressor__scale']}, offset={pipe.get_params()['regressor__offset']}")
+    return (pipe,)
+
+
+@app.cell
+def _(FunctionRegressor, GridSearchCV, X_train, mo, scaled_predict, y_train):
+    # GridSearchCV over function config params
+    grid = GridSearchCV(
+        FunctionRegressor(fn=scaled_predict),
+        param_grid={"scale": [0.5, 1.0, 2.0, 3.0], "offset": [0.0, 0.5, 1.0]},
+        cv=3,
+        scoring="neg_mean_squared_error",
+    )
+    grid.fit(X_train, y_train)
+    mo.md(f"**Best params:** `{grid.best_params_}`  \n**Best score:** `{grid.best_score_:.4f}`")
+    return (grid,)
+
+
+@app.cell
+def _(FunctionRegressor, X_train, cross_val_score, mo, scaled_predict, y_train):
+    # Cross-validation
+    scores = cross_val_score(
+        FunctionRegressor(fn=scaled_predict, scale=2.0, offset=1.0),
+        X_train, y_train,
+        cv=5,
+        scoring="neg_mean_squared_error",
+    )
+    mo.md(f"**CV scores:** `{scores.round(4)}`  \n**Mean:** `{scores.mean():.4f}`")
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md("""
+    ## 5. HTML Representation
+
+    Wrapped functions display nicely in interactive environments, just like
+    class-based estimators.
+    """)
+    return
+
+
+@app.cell
+def _(grid):
+    grid.best_estimator_
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md("""
+    ## What We Built
+
+    We wrapped a standalone function into an sklearn-compatible functor using
+    `FunctionWrapper`. Along the way, we:
+
+    - Used the keyword-only convention to separate data from config parameters
+    - Called the wrapper as a functor with `__call__`
+    - Created a full estimator by adding `RegressorMixin` and `_fit_context`
+    - Used the wrapper in `Pipeline` and `GridSearchCV`
+
+    **Next steps:**
+
+    - Wrapping classes instead of functions:
+      [View](/examples/first_wrapper/) · [Open in marimo](/examples/first_wrapper/edit/)
+    - The fit context decorator:
+      [View](/examples/fit_context/) · [Open in marimo](/examples/fit_context/edit/)
+    """)
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -141,10 +141,12 @@ nav:
   - Tutorials:
     - pages/tutorials/index.md
     - Getting Started: pages/tutorials/getting-started.md
+    - Wrapping Functions: pages/tutorials/wrapping-functions.md
     - Examples: pages/tutorials/examples.md
   - How-to Guides:
     - pages/how-to/index.md
     - Wrap a Class: pages/how-to/wrap-a-class.md
+    - Wrap Functions: pages/how-to/wrap-functions.md
     - Validate Parameters: pages/how-to/validate-parameters.md
     - Use YAML Configuration: pages/how-to/yaml-configuration.md
     - Advanced YAML Patterns: pages/how-to/yaml-advanced.md
@@ -161,6 +163,7 @@ nav:
   - Explanation:
     - pages/explanation/index.md
     - The Delegation Pattern: pages/explanation/delegation-pattern.md
+    - Function Wrapping: pages/explanation/function-wrapping.md
     - The Fit Context Lifecycle: pages/explanation/fit-context-lifecycle.md
     - Trade-offs and Limitations: pages/explanation/trade-offs.md
     - YAML Configuration Design: pages/explanation/yaml-config-design.md

--- a/src/sklearn_wrap/__init__.py
+++ b/src/sklearn_wrap/__init__.py
@@ -2,13 +2,14 @@
 
 from importlib.metadata import version
 
-from .base import REQUIRED_PARAM_VALUE, BaseClassWrapper
+from .base import REQUIRED_PARAM_VALUE, BaseClassWrapper, FunctionWrapper
 
 __version__ = version(__name__)
 
 __all__ = [
     "__version__",
     "BaseClassWrapper",
+    "FunctionWrapper",
     "REQUIRED_PARAM_VALUE",
 ]
 

--- a/src/sklearn_wrap/_validation.py
+++ b/src/sklearn_wrap/_validation.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import inspect
 from typing import Any
 
-__all__ = ["validate_class_params", "validate_dotted_path"]
+__all__ = ["validate_class_params", "validate_dotted_path", "validate_function_params"]
 
 _REQUIRED_PARAM_VALUE = "__REQUIRED__"
 """Local alias so this module does not import from base (avoids circular deps)."""
@@ -109,6 +109,74 @@ def validate_class_params(cls: type, params: dict[str, Any]) -> dict[str, Any]:
         validated[param_name] = param_val
 
     for param_name, default in valid_class_params.items():
+        if param_name not in params:
+            validated[param_name] = _REQUIRED_PARAM_VALUE if default is inspect._empty else default
+
+    return validated
+
+
+def validate_function_params(fn: Any, params: dict[str, Any]) -> dict[str, Any]:
+    """Validate parameter names against a callable's keyword-only signature.
+
+    Inspects the signature of *fn*, extracts only ``KEYWORD_ONLY`` parameters
+    as valid config params (positional kinds are data params, passed at call
+    time). If ``VAR_KEYWORD`` (``**kwargs``) is present, arbitrary extra config
+    params are accepted.
+
+    Parameters
+    ----------
+    fn : callable
+        The callable whose signature will be inspected.
+    params : dict[str, Any]
+        Parameter names and values to validate.
+
+    Returns
+    -------
+    dict[str, Any]
+        Validated parameters, including defaults for omitted keyword-only
+        params. Required params without defaults are set to the sentinel
+        ``"__REQUIRED__"``.
+
+    Raises
+    ------
+    TypeError
+        If *fn*'s signature cannot be inspected.
+    ValueError
+        If *params* contains a key that is not a keyword-only parameter of
+        *fn* (and *fn* does not accept ``**kwargs``).
+
+    Examples
+    --------
+    >>> def my_fn(X, y, *, alpha=1.0, beta=2.0): ...
+    >>> validate_function_params(my_fn, {"alpha": 5.0})
+    {'alpha': 5.0, 'beta': 2.0}
+
+    See Also
+    --------
+    validate_class_params : Validate constructor parameters against a class signature.
+    """
+    try:
+        sig = inspect.signature(fn)
+    except (ValueError, TypeError) as exc:
+        raise TypeError(
+            f"Cannot inspect signature of {fn!r}. FunctionWrapper requires a callable with an inspectable signature."
+        ) from exc
+
+    has_var_keyword = any(p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values())
+
+    valid_kw_only: dict[str, Any] = {
+        key: val.default for key, val in sig.parameters.items() if val.kind == inspect.Parameter.KEYWORD_ONLY
+    }
+
+    validated: dict[str, Any] = {}
+    for param_name, param_val in params.items():
+        if param_name not in valid_kw_only and not has_var_keyword:
+            raise ValueError(
+                f"{param_name!r} is not a valid keyword-only parameter for callable {getattr(fn, '__name__', repr(fn))!r}."
+            )
+        validated[param_name] = param_val
+
+    for param_name, default in valid_kw_only.items():
         if param_name not in params:
             validated[param_name] = _REQUIRED_PARAM_VALUE if default is inspect._empty else default
 

--- a/src/sklearn_wrap/base.py
+++ b/src/sklearn_wrap/base.py
@@ -8,9 +8,9 @@ from sklearn._config import config_context, get_config
 from sklearn.base import BaseEstimator
 from sklearn.utils.validation import _is_fitted
 
-from ._validation import validate_class_params
+from ._validation import validate_class_params, validate_function_params
 
-__all__ = ["BaseClassWrapper"]
+__all__ = ["BaseClassWrapper", "FunctionWrapper"]
 
 
 REQUIRED_PARAM_VALUE = "__REQUIRED__"
@@ -510,6 +510,359 @@ class BaseClassWrapper(BaseEstimator, metaclass=abc.ABCMeta):
         # Step 5: Recursively set nested parameters
         for base_key, sub_params in nested_params.items():
             nested_obj = self.params[base_key]
+            if not hasattr(nested_obj, "set_params"):
+                raise AttributeError(
+                    f"Cannot set nested parameters on {base_key!r}. "
+                    f"Object of type {type(nested_obj).__name__!r} does not have a set_params method."
+                )
+            nested_obj.set_params(**sub_params)
+
+        return self
+
+
+class FunctionWrapper(BaseEstimator):
+    """Base class for wrapping callables into scikit-learn compatible functors.
+
+    Inheriting from this class provides:
+
+    - setting and getting parameters used by ``GridSearchCV`` and friends;
+    - textual and HTML representation displayed in terminals and IDEs;
+    - estimator serialization via ``clone()``;
+    - parameter validation;
+    - ``__call__`` forwarding positional data args and injecting stored config params.
+
+    Configuration params are identified via the keyword-only convention:
+    positional params in the wrapped callable's signature are data (passed at
+    call time via ``__call__``), keyword-only params (after ``*``) are config
+    (stored on the wrapper and managed via ``get_params``/``set_params``).
+
+    Subclasses can add sklearn mixins (e.g. ``RegressorMixin``) and implement
+    ``fit``/``predict``/``transform`` decorated with ``_fit_context`` to turn
+    the functor into a proper estimator.
+
+    Parameters
+    ----------
+    **params
+        The keyword argument matching ``_callable_name`` provides the callable
+        to wrap (optional when ``_callable_default`` is set).
+        Remaining keyword arguments are passed as keyword-only config params
+        to the wrapped callable.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sklearn_wrap.base import FunctionWrapper
+    >>>
+    >>> def my_predict(X, *, scale=1.0, offset=0.0):
+    ...     return X.sum(axis=1) * scale + offset
+    >>>
+    >>> class ScaledPredictor(FunctionWrapper):
+    ...     _callable_name = "fn"
+    >>>
+    >>> wrapper = ScaledPredictor(fn=my_predict, scale=2.0)
+    >>> wrapper.get_params()["scale"]
+    2.0
+    >>> wrapper(np.array([[1, 2], [3, 4]]))
+    array([ 6., 14.])
+
+    See Also
+    --------
+    BaseClassWrapper : Wraps a class (with instance lifecycle) into an sklearn estimator.
+    _fit_context : Decorator for automatic validation during fit.
+    """
+
+    _required_parameters: list[str] = []
+    _callable_name: str | None = None
+    _callable_default = None
+
+    def __init_subclass__(cls, **kwargs):
+        """Set ``_required_parameters`` automatically for subclasses.
+
+        When a subclass defines ``_callable_name`` and optionally
+        ``_callable_default``, this hook populates ``_required_parameters``
+        so that scikit-learn utilities (e.g. ``clone``) know which
+        constructor arguments are mandatory.
+
+        See Also
+        --------
+        FunctionWrapper.__init__ : Constructor that consumes the required parameter.
+        """
+        super().__init_subclass__(**kwargs)
+        name = getattr(cls, "_callable_name", None)
+        if isinstance(name, str):
+            has_default = getattr(cls, "_callable_default", None) is not None
+            cls._required_parameters = [] if has_default else [name]
+
+    def __init__(self, **params):
+        name = self._callable_name
+        if not isinstance(name, str):
+            raise ValueError("Class should define a static `_callable_name`.")
+
+        if name not in params:
+            # Access from the class to avoid descriptor binding (a function
+            # stored as a class attribute would become a bound method if
+            # accessed via self, causing repr recursion).
+            default_fn = type(self)._callable_default
+            if default_fn is not None:
+                params[name] = default_fn
+            else:
+                raise TypeError(f"{self.__class__.__name__}.__init__() missing required keyword argument: '{name}'")
+        callable_fn = params.pop(name)
+
+        self.callable_fn = self._validate_estimator_fn(callable_fn)
+        self._params = self._validate_function_params(params)
+
+    def _validate_estimator_fn(self, fn):
+        """Validate that the value is callable and inspectable.
+
+        Parameters
+        ----------
+        fn : callable
+            The callable to validate.
+
+        Returns
+        -------
+        callable
+            The validated callable.
+
+        Raises
+        ------
+        TypeError
+            If *fn* is not callable or its signature cannot be inspected.
+
+        See Also
+        --------
+        FunctionWrapper._validate_function_params : Validates config parameter names.
+        """
+        if not callable(fn):
+            raise TypeError(
+                f"{self._callable_name} parameter for {self.__class__.__name__} is not callable. It is {fn!r}."
+            )
+
+        try:
+            inspect.signature(fn)
+        except (ValueError, TypeError) as exc:
+            raise TypeError(
+                f"Cannot inspect signature of {fn!r}. "
+                f"FunctionWrapper requires a callable with an inspectable signature."
+            ) from exc
+
+        return fn
+
+    def _validate_function_params(self, params):
+        """Validate config parameter names against the callable's signature.
+
+        Parameters
+        ----------
+        params : dict
+            Parameter names and values to validate.
+
+        Returns
+        -------
+        dict
+            Validated parameters with defaults filled in.
+
+        See Also
+        --------
+        FunctionWrapper._validate_estimator_fn : Validates the callable itself.
+        FunctionWrapper._validate_params : Full validation combining callable and params.
+        """
+        for param_name in params:
+            if "__" in param_name:
+                raise ValueError(
+                    f"Parameter name {param_name!r} cannot contain '__' (double underscore). "
+                    f"This delimiter is reserved for nested parameter syntax."
+                )
+
+        return validate_function_params(self.callable_fn, params)
+
+    def _validate_params(self):
+        """Validate the callable and all config parameters.
+
+        See Also
+        --------
+        FunctionWrapper._validate_estimator_fn : Validates the callable.
+        FunctionWrapper._validate_function_params : Validates config parameter names.
+        """
+        self._validate_estimator_fn(self.callable_fn)
+        self._validate_function_params(self._params)
+
+    def __sklearn_is_fitted__(self) -> bool:
+        """Check if the estimator has been fitted.
+
+        Checks for fitted attributes (attributes ending with ``_``, excluding
+        ``callable_fn``), which is the sklearn convention. Also checks the
+        internal ``_fitted`` flag.
+
+        Returns
+        -------
+        bool
+            True if the estimator has fitted attributes, False otherwise.
+
+        See Also
+        --------
+        _fit_context : Decorator that sets the fitted state after successful fit.
+        """
+        if getattr(self, "_fitted", False):
+            return True
+
+        fitted_attrs = [v for v in vars(self) if v.endswith("_") and not v.startswith("__") and v != "callable_fn"]
+        return len(fitted_attrs) > 0
+
+    def instantiate(self) -> "FunctionWrapper":
+        """Validate parameters and check for required sentinels.
+
+        Unlike ``BaseClassWrapper.instantiate()``, this does not create a
+        wrapped instance (there is no instance lifecycle). It validates
+        parameters and ensures no required params remain unset.
+
+        Returns
+        -------
+        self
+
+        Raises
+        ------
+        ValueError
+            If any config parameter is still set to the required sentinel.
+
+        See Also
+        --------
+        _fit_context : Decorator that calls instantiate automatically during fit.
+        FunctionWrapper._validate_params : Parameter validation called by this method.
+        """
+        self._validate_params()
+
+        for param_name, param_value in self._params.items():
+            if param_value == REQUIRED_PARAM_VALUE:
+                raise ValueError(
+                    f"Callable {getattr(self.callable_fn, '__name__', repr(self.callable_fn))!r} "
+                    f"requires parameter {param_name!r}."
+                )
+
+        return self
+
+    def __call__(self, *args):
+        """Invoke the wrapped callable with stored config params.
+
+        Positional data arguments are forwarded to the callable. Stored
+        keyword-only config params are injected automatically.
+
+        Parameters
+        ----------
+        *args
+            Positional data arguments forwarded to the wrapped callable.
+
+        Returns
+        -------
+        result
+            The return value of the wrapped callable.
+
+        See Also
+        --------
+        FunctionWrapper.instantiate : Validation step called before invocation.
+        """
+        self.instantiate()
+        return self.callable_fn(*args, **self._params)
+
+    def get_params(self, deep: bool = True) -> dict[str, Any]:
+        """Get parameters for this estimator.
+
+        Parameters
+        ----------
+        deep : bool, default=True
+            If True, will return the parameters for this estimator and
+            contained subobjects that are estimators.
+
+        Returns
+        -------
+        params : dict
+            Parameter names mapped to their values.
+
+        Notes
+        -----
+        The callable is always returned under the ``_callable_name`` key.
+        This ensures that ``sklearn.base.clone()`` can reconstruct the wrapper
+        correctly.
+
+        See Also
+        --------
+        FunctionWrapper.set_params : Set parameters on this estimator.
+        """
+        out = {}
+        for key, value in self._params.items():
+            if deep and hasattr(value, "get_params") and not isinstance(value, type):
+                deep_items = value.get_params().items()
+                if isinstance(value, BaseClassWrapper):
+                    estimator_name = value._estimator_name
+                    deep_items = [(k, v) for k, v in deep_items if k != estimator_name]
+                elif isinstance(value, FunctionWrapper):
+                    callable_name = value._callable_name
+                    deep_items = [(k, v) for k, v in deep_items if k != callable_name]
+                out.update((key + "__" + k, val) for k, val in deep_items)
+            out[key] = value
+
+        out[self._callable_name] = self.callable_fn
+
+        return out
+
+    def set_params(self, **params: object) -> "FunctionWrapper":
+        """Set the parameters of this estimator.
+
+        Works on simple parameters as well as nested objects with parameters
+        of the form ``<component>__<parameter>``.
+
+        Parameters
+        ----------
+        **params : dict
+            Estimator parameters.
+
+        Returns
+        -------
+        self : FunctionWrapper
+            This estimator instance.
+
+        See Also
+        --------
+        FunctionWrapper.get_params : Get parameters for this estimator.
+        """
+        if not params:
+            return self
+
+        if self._callable_name in params:
+            raise ValueError(
+                f"Cannot change callable via set_params. "
+                f"The '{self._callable_name}' parameter cannot be set. Redeclare the "
+                f"callable by creating a new instance of {self.__class__.__name__}."
+            )
+
+        simple_params = {}
+        nested_params = defaultdict(dict)
+        has_nested = False
+
+        for full_key, value in params.items():
+            base_key, delim, sub_key = full_key.partition("__")
+            if delim:
+                nested_params[base_key][sub_key] = value
+                has_nested = True
+            else:
+                simple_params[base_key] = value
+
+        if simple_params:
+            self._validate_function_params(simple_params)
+
+        if has_nested:
+            for base_key in nested_params:
+                if base_key not in self._params:
+                    raise ValueError(
+                        f"Invalid parameter {base_key!r} for estimator {self}. "
+                        f"Valid parameters are: {list(self._params.keys())!r}."
+                    )
+
+        for key, value in simple_params.items():
+            self._params[key] = value
+
+        for base_key, sub_params in nested_params.items():
+            nested_obj = self._params[base_key]
             if not hasattr(nested_obj, "set_params"):
                 raise AttributeError(
                     f"Cannot set nested parameters on {base_key!r}. "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,9 @@
 """Shared pytest fixtures and helper classes for sklearn-wrap tests."""
 
+import numpy as np
 import pytest
 
-from sklearn_wrap.base import BaseClassWrapper
+from sklearn_wrap.base import BaseClassWrapper, FunctionWrapper
 
 
 class BaseTestClass:
@@ -134,3 +135,73 @@ def missing_base_class_wrapper():
 def required_param_value():
     """Fixture providing test value for required parameters."""
     return REQUIRED_PARAM_TEST_VALUE
+
+
+# ---------------------------------------------------------------------------
+# FunctionWrapper test helpers
+# ---------------------------------------------------------------------------
+
+
+def simple_fn(X, y, *, alpha=1.0, beta=2.0):
+    """Function with keyword-only config params."""
+    return X * alpha + beta
+
+
+def required_param_fn(X, *, gamma):
+    """Function with a required keyword-only param (no default)."""
+    return X * gamma
+
+
+def kwargs_fn(X, *, base=1.0, **extra):
+    """Function accepting arbitrary keyword-only params via **kwargs."""
+    return X * base + sum(extra.values())
+
+
+def no_config_fn(X, y):
+    """Function with no keyword-only params (data-only)."""
+    return X + y
+
+
+def predict_fn(X, *, scale=1.0, offset=0.0):
+    """A predict-style function for integration tests."""
+    return X.sum(axis=1) * scale + offset
+
+
+class SimpleFunctionWrapper(FunctionWrapper):
+    """Concrete FunctionWrapper subclass for testing."""
+
+    _callable_name = "fn"
+
+
+class DefaultCallableWrapper(FunctionWrapper):
+    """FunctionWrapper with a default callable."""
+
+    _callable_name = "fn"
+    _callable_default = simple_fn
+
+
+class FitPredictFunctionWrapper(FunctionWrapper):
+    """FunctionWrapper subclass with fit/predict for estimator tests."""
+
+    _callable_name = "fn"
+
+    def fit(self, X, y=None):
+        self.fitted_ = True
+        self.n_features_in_ = X.shape[1] if hasattr(X, "shape") else len(X[0])
+        return self
+
+    def predict(self, X):
+        X = np.asarray(X)
+        return self.callable_fn(X, **self._params)
+
+
+@pytest.fixture
+def simple_function_wrapper():
+    """Fixture providing SimpleFunctionWrapper class."""
+    return SimpleFunctionWrapper
+
+
+@pytest.fixture
+def default_callable_wrapper():
+    """Fixture providing DefaultCallableWrapper class."""
+    return DefaultCallableWrapper

--- a/tests/test_function_wrapper_core.py
+++ b/tests/test_function_wrapper_core.py
@@ -92,6 +92,15 @@ class TestValidation:
         with pytest.raises(TypeError, match="not callable"):
             SimpleFunctionWrapper(fn=42)
 
+    def test_validate_callable_uninspectable_signature(self):
+        class BadCallable:
+            def __call__(self): ...
+
+            __signature__ = property(lambda self: (_ for _ in ()).throw(ValueError("no sig")))
+
+        with pytest.raises(TypeError, match="Cannot inspect signature"):
+            SimpleFunctionWrapper(fn=BadCallable())
+
     def test_validate_params_called_by_instantiate(self):
         wrapper = SimpleFunctionWrapper(fn=simple_fn, alpha=5.0)
         wrapper.instantiate()  # should not raise

--- a/tests/test_function_wrapper_core.py
+++ b/tests/test_function_wrapper_core.py
@@ -1,0 +1,164 @@
+"""Tests for FunctionWrapper core functionality: init, validation, __call__, fitted checks."""
+
+import pytest
+
+from sklearn_wrap.base import REQUIRED_PARAM_VALUE, FunctionWrapper
+
+from .conftest import (
+    DefaultCallableWrapper,
+    SimpleFunctionWrapper,
+    kwargs_fn,
+    no_config_fn,
+    predict_fn,
+    required_param_fn,
+    simple_fn,
+)
+
+
+class TestInit:
+    """Tests for FunctionWrapper.__init__."""
+
+    def test_init_with_callable_and_params(self):
+        wrapper = SimpleFunctionWrapper(fn=simple_fn, alpha=5.0)
+        assert wrapper.callable_fn is simple_fn
+        assert wrapper._params["alpha"] == 5.0
+        assert wrapper._params["beta"] == 2.0  # default filled
+
+    def test_init_with_default_callable(self):
+        wrapper = DefaultCallableWrapper()
+        assert wrapper.callable_fn is simple_fn
+        assert wrapper._params["alpha"] == 1.0
+        assert wrapper._params["beta"] == 2.0
+
+    def test_init_override_default_callable(self):
+        wrapper = DefaultCallableWrapper(fn=predict_fn, scale=3.0)
+        assert wrapper.callable_fn is predict_fn
+        assert wrapper._params["scale"] == 3.0
+
+    def test_init_missing_callable_raises(self):
+        with pytest.raises(TypeError, match="missing required keyword argument"):
+            SimpleFunctionWrapper(alpha=1.0)
+
+    def test_init_no_callable_name_raises(self):
+        class BadWrapper(FunctionWrapper):
+            pass
+
+        with pytest.raises(ValueError, match="`_callable_name`"):
+            BadWrapper(fn=simple_fn)
+
+    def test_init_not_callable_raises(self):
+        with pytest.raises(TypeError, match="not callable"):
+            SimpleFunctionWrapper(fn="not_a_function")
+
+    def test_init_required_param_gets_sentinel(self):
+        wrapper = SimpleFunctionWrapper(fn=required_param_fn)
+        assert wrapper._params["gamma"] == REQUIRED_PARAM_VALUE
+
+    def test_init_no_config_params(self):
+        wrapper = SimpleFunctionWrapper(fn=no_config_fn)
+        assert wrapper._params == {}
+
+    def test_init_kwargs_fn_accepts_extra_params(self):
+        wrapper = SimpleFunctionWrapper(fn=kwargs_fn, base=2.0, extra_param=10.0)
+        assert wrapper._params["base"] == 2.0
+        assert wrapper._params["extra_param"] == 10.0
+
+    def test_init_invalid_param_raises(self):
+        with pytest.raises(ValueError, match="not a valid keyword-only parameter"):
+            SimpleFunctionWrapper(fn=simple_fn, nonexistent=1.0)
+
+    def test_init_double_underscore_param_raises(self):
+        with pytest.raises(ValueError, match="cannot contain '__'"):
+            SimpleFunctionWrapper(fn=kwargs_fn, bad__param=1.0)
+
+    def test_init_lambda(self):
+        fn = lambda X, *, k=1: X * k  # noqa: E731
+        wrapper = SimpleFunctionWrapper(fn=fn, k=3)
+        assert wrapper._params["k"] == 3
+
+    def test_init_class_as_callable(self):
+        class MyCallable:
+            def __init__(self, *, value=10):
+                self.value = value
+
+        wrapper = SimpleFunctionWrapper(fn=MyCallable, value=42)
+        assert wrapper._params["value"] == 42
+
+
+class TestValidation:
+    """Tests for validation methods."""
+
+    def test_validate_estimator_fn_not_callable(self):
+        with pytest.raises(TypeError, match="not callable"):
+            SimpleFunctionWrapper(fn=42)
+
+    def test_validate_params_called_by_instantiate(self):
+        wrapper = SimpleFunctionWrapper(fn=simple_fn, alpha=5.0)
+        wrapper.instantiate()  # should not raise
+
+    def test_instantiate_required_sentinel_raises(self):
+        wrapper = SimpleFunctionWrapper(fn=required_param_fn)
+        with pytest.raises(ValueError, match="requires parameter 'gamma'"):
+            wrapper.instantiate()
+
+
+class TestCall:
+    """Tests for FunctionWrapper.__call__."""
+
+    def test_call_with_defaults(self):
+        wrapper = SimpleFunctionWrapper(fn=simple_fn)
+        result = wrapper(10, 0)  # X=10, y=0 (data args)
+        assert result == 10 * 1.0 + 2.0  # alpha=1.0, beta=2.0
+
+    def test_call_with_custom_params(self):
+        wrapper = SimpleFunctionWrapper(fn=simple_fn, alpha=3.0, beta=0.0)
+        result = wrapper(5, 0)
+        assert result == 5 * 3.0 + 0.0
+
+    def test_call_required_param_raises(self):
+        wrapper = SimpleFunctionWrapper(fn=required_param_fn)
+        with pytest.raises(ValueError, match="requires parameter"):
+            wrapper(10)
+
+    def test_call_no_config_params(self):
+        wrapper = SimpleFunctionWrapper(fn=no_config_fn)
+        result = wrapper(3, 7)
+        assert result == 10
+
+    def test_call_kwargs_fn(self):
+        wrapper = SimpleFunctionWrapper(fn=kwargs_fn, base=2.0, bonus=5.0)
+        result = wrapper(10)  # 10 * 2.0 + 5.0
+        assert result == 25.0
+
+
+class TestFitted:
+    """Tests for __sklearn_is_fitted__."""
+
+    def test_not_fitted_initially(self):
+        wrapper = SimpleFunctionWrapper(fn=simple_fn)
+        assert not wrapper.__sklearn_is_fitted__()
+
+    def test_fitted_after_setting_flag(self):
+        wrapper = SimpleFunctionWrapper(fn=simple_fn)
+        wrapper._fitted = True
+        assert wrapper.__sklearn_is_fitted__()
+
+    def test_fitted_with_fitted_attribute(self):
+        wrapper = SimpleFunctionWrapper(fn=simple_fn)
+        wrapper.some_fitted_attr_ = 42
+        assert wrapper.__sklearn_is_fitted__()
+
+    def test_callable_fn_not_counted_as_fitted(self):
+        wrapper = SimpleFunctionWrapper(fn=simple_fn)
+        # callable_fn ends with _ but should be excluded
+        assert not wrapper.__sklearn_is_fitted__()
+
+
+class TestInitSubclass:
+    """Tests for __init_subclass__ auto-setting _required_parameters."""
+
+    def test_required_parameters_no_default(self):
+        assert SimpleFunctionWrapper._required_parameters == ["fn"]
+
+    def test_required_parameters_with_default(self):
+        assert DefaultCallableWrapper._required_parameters == []

--- a/tests/test_function_wrapper_integration.py
+++ b/tests/test_function_wrapper_integration.py
@@ -1,0 +1,139 @@
+"""Integration tests: FunctionWrapper subclass with mixins in Pipeline, GridSearchCV."""
+
+import numpy as np
+import pytest
+from sklearn.base import RegressorMixin, clone
+from sklearn.model_selection import GridSearchCV, cross_val_score
+from sklearn.pipeline import Pipeline
+
+from sklearn_wrap.base import FunctionWrapper, _fit_context
+
+from .conftest import FitPredictFunctionWrapper, predict_fn
+
+
+class RegressorFunctionWrapper(FunctionWrapper, RegressorMixin):
+    """Full estimator built from FunctionWrapper with _fit_context."""
+
+    _callable_name = "fn"
+
+    @_fit_context(prefer_skip_nested_validation=True)
+    def fit(self, X, y=None):
+        self.n_features_in_ = np.asarray(X).shape[1]
+        return self
+
+    def predict(self, X):
+        X = np.asarray(X)
+        return self.callable_fn(X, **self._params)
+
+
+@pytest.fixture
+def sample_data():
+    rng = np.random.RandomState(42)
+    X = rng.randn(50, 3)
+    y = X.sum(axis=1) * 2.0 + 1.0
+    return X, y
+
+
+class TestFitContext:
+    """Tests for _fit_context integration with FunctionWrapper."""
+
+    def test_fit_context_calls_instantiate(self, sample_data):
+        X, y = sample_data
+        wrapper = RegressorFunctionWrapper(fn=predict_fn, scale=2.0, offset=1.0)
+        wrapper.fit(X, y)
+        assert wrapper.__sklearn_is_fitted__()
+
+    def test_fit_context_sets_fitted(self, sample_data):
+        X, y = sample_data
+        wrapper = RegressorFunctionWrapper(fn=predict_fn)
+        assert not wrapper.__sklearn_is_fitted__()
+        wrapper.fit(X, y)
+        assert wrapper.__sklearn_is_fitted__()
+
+    def test_fit_predict(self, sample_data):
+        X, y = sample_data
+        wrapper = RegressorFunctionWrapper(fn=predict_fn, scale=2.0, offset=1.0)
+        wrapper.fit(X, y)
+        predictions = wrapper.predict(X)
+        expected = X.sum(axis=1) * 2.0 + 1.0
+        np.testing.assert_array_almost_equal(predictions, expected)
+
+
+class TestPipeline:
+    """Tests for FunctionWrapper in sklearn Pipeline."""
+
+    def test_pipeline_fit_predict(self, sample_data):
+        X, y = sample_data
+        pipe = Pipeline([("regressor", RegressorFunctionWrapper(fn=predict_fn, scale=1.0))])
+        pipe.fit(X, y)
+        predictions = pipe.predict(X)
+        assert predictions.shape == (50,)
+
+    def test_pipeline_set_params(self, sample_data):
+        X, y = sample_data
+        pipe = Pipeline([("regressor", RegressorFunctionWrapper(fn=predict_fn, scale=1.0))])
+        pipe.set_params(regressor__scale=3.0)
+        assert pipe.named_steps["regressor"]._params["scale"] == 3.0
+
+    def test_pipeline_get_params(self):
+        pipe = Pipeline([("regressor", RegressorFunctionWrapper(fn=predict_fn, scale=2.0))])
+        params = pipe.get_params()
+        assert params["regressor__scale"] == 2.0
+        assert params["regressor__offset"] == 0.0
+
+
+class TestGridSearchCV:
+    """Tests for FunctionWrapper with GridSearchCV."""
+
+    def test_grid_search(self, sample_data):
+        X, y = sample_data
+        wrapper = RegressorFunctionWrapper(fn=predict_fn, scale=1.0, offset=0.0)
+        grid = GridSearchCV(
+            wrapper,
+            param_grid={"scale": [0.5, 1.0, 2.0], "offset": [0.0, 1.0]},
+            cv=3,
+            scoring="neg_mean_squared_error",
+        )
+        grid.fit(X, y)
+        assert "scale" in grid.best_params_
+        assert "offset" in grid.best_params_
+
+    def test_cross_val_score(self, sample_data):
+        X, y = sample_data
+        wrapper = RegressorFunctionWrapper(fn=predict_fn, scale=2.0, offset=1.0)
+        scores = cross_val_score(wrapper, X, y, cv=3, scoring="neg_mean_squared_error")
+        assert len(scores) == 3
+
+
+class TestCloneEstimator:
+    """Tests for clone of estimator-style FunctionWrapper."""
+
+    def test_clone_regressor_wrapper(self, sample_data):
+        X, y = sample_data
+        wrapper = RegressorFunctionWrapper(fn=predict_fn, scale=2.0, offset=1.0)
+        wrapper.fit(X, y)
+        cloned = clone(wrapper)
+        assert not cloned.__sklearn_is_fitted__()
+        assert cloned.callable_fn is predict_fn
+        assert cloned._params["scale"] == 2.0
+
+    def test_clone_in_pipeline(self, sample_data):
+        X, y = sample_data
+        pipe = Pipeline([("regressor", RegressorFunctionWrapper(fn=predict_fn, scale=1.5))])
+        cloned_pipe = clone(pipe)
+        cloned_pipe.fit(X, y)
+        predictions = cloned_pipe.predict(X)
+        assert predictions.shape == (50,)
+
+
+class TestFitPredictWrapper:
+    """Tests for the simpler FitPredictFunctionWrapper fixture (no _fit_context)."""
+
+    def test_fit_predict(self, sample_data):
+        X, y = sample_data
+        wrapper = FitPredictFunctionWrapper(fn=predict_fn, scale=2.0, offset=0.5)
+        wrapper.fit(X, y)
+        assert wrapper.__sklearn_is_fitted__()
+        predictions = wrapper.predict(X)
+        expected = X.sum(axis=1) * 2.0 + 0.5
+        np.testing.assert_array_almost_equal(predictions, expected)

--- a/tests/test_function_wrapper_params.py
+++ b/tests/test_function_wrapper_params.py
@@ -9,7 +9,9 @@ from sklearn_wrap.base import FunctionWrapper
 
 from .conftest import (
     DefaultCallableWrapper,
+    NoRequiredParams,
     SimpleFunctionWrapper,
+    SimpleWrapper,
     kwargs_fn,
     predict_fn,
     simple_fn,
@@ -51,6 +53,32 @@ class TestGetParams:
         assert params["inner__beta"] == 2.0
         # callable key of nested wrapper should NOT appear in flattened params
         assert "inner__fn" not in params
+
+    def test_get_params_nested_base_class_wrapper(self):
+        inner = SimpleWrapper(simple=NoRequiredParams, param1=99)
+
+        class OuterWrapper(FunctionWrapper):
+            _callable_name = "fn"
+
+        outer = OuterWrapper(fn=kwargs_fn, base=1.0, nested=inner)
+        params = outer.get_params(deep=True)
+        assert params["nested"] is inner
+        assert params["nested__param1"] == 99
+        # estimator_name key of nested BaseClassWrapper should NOT appear
+        assert "nested__simple" not in params
+
+    def test_get_params_nested_plain_estimator(self):
+        from sklearn.tree import DecisionTreeClassifier
+
+        inner = DecisionTreeClassifier(max_depth=3)
+
+        class OuterWrapper(FunctionWrapper):
+            _callable_name = "fn"
+
+        outer = OuterWrapper(fn=kwargs_fn, base=1.0, tree=inner)
+        params = outer.get_params(deep=True)
+        assert params["tree"] is inner
+        assert params["tree__max_depth"] == 3
 
 
 class TestSetParams:

--- a/tests/test_function_wrapper_params.py
+++ b/tests/test_function_wrapper_params.py
@@ -1,0 +1,183 @@
+"""Tests for FunctionWrapper get_params, set_params, clone roundtrip."""
+
+import functools
+
+import pytest
+from sklearn.base import clone
+
+from sklearn_wrap.base import FunctionWrapper
+
+from .conftest import (
+    DefaultCallableWrapper,
+    SimpleFunctionWrapper,
+    kwargs_fn,
+    predict_fn,
+    simple_fn,
+)
+
+
+class TestGetParams:
+    """Tests for FunctionWrapper.get_params."""
+
+    def test_get_params_includes_callable(self):
+        wrapper = SimpleFunctionWrapper(fn=simple_fn, alpha=5.0)
+        params = wrapper.get_params()
+        assert params["fn"] is simple_fn
+        assert params["alpha"] == 5.0
+        assert params["beta"] == 2.0
+
+    def test_get_params_default_callable(self):
+        wrapper = DefaultCallableWrapper()
+        params = wrapper.get_params()
+        assert params["fn"] is simple_fn
+        assert params["alpha"] == 1.0
+
+    def test_get_params_deep_false(self):
+        wrapper = SimpleFunctionWrapper(fn=simple_fn, alpha=5.0)
+        params = wrapper.get_params(deep=False)
+        assert params["fn"] is simple_fn
+        assert params["alpha"] == 5.0
+
+    def test_get_params_nested_wrapper(self):
+        inner = SimpleFunctionWrapper(fn=simple_fn, alpha=3.0)
+
+        class OuterWrapper(FunctionWrapper):
+            _callable_name = "fn"
+
+        outer = OuterWrapper(fn=kwargs_fn, base=1.0, inner=inner)
+        params = outer.get_params(deep=True)
+        assert params["inner"] is inner
+        assert params["inner__alpha"] == 3.0
+        assert params["inner__beta"] == 2.0
+        # callable key of nested wrapper should NOT appear in flattened params
+        assert "inner__fn" not in params
+
+
+class TestSetParams:
+    """Tests for FunctionWrapper.set_params."""
+
+    def test_set_simple_params(self):
+        wrapper = SimpleFunctionWrapper(fn=simple_fn, alpha=1.0)
+        wrapper.set_params(alpha=10.0)
+        assert wrapper._params["alpha"] == 10.0
+
+    def test_set_params_returns_self(self):
+        wrapper = SimpleFunctionWrapper(fn=simple_fn)
+        result = wrapper.set_params(alpha=2.0)
+        assert result is wrapper
+
+    def test_set_params_rejects_callable_change(self):
+        wrapper = SimpleFunctionWrapper(fn=simple_fn)
+        with pytest.raises(ValueError, match="Cannot change callable"):
+            wrapper.set_params(fn=predict_fn)
+
+    def test_set_params_empty(self):
+        wrapper = SimpleFunctionWrapper(fn=simple_fn)
+        result = wrapper.set_params()
+        assert result is wrapper
+
+    def test_set_params_invalid_raises(self):
+        wrapper = SimpleFunctionWrapper(fn=simple_fn)
+        with pytest.raises(ValueError, match="not a valid keyword-only parameter"):
+            wrapper.set_params(nonexistent=1.0)
+
+    def test_set_nested_params(self):
+        inner = SimpleFunctionWrapper(fn=simple_fn, alpha=1.0)
+
+        class OuterWrapper(FunctionWrapper):
+            _callable_name = "fn"
+
+        outer = OuterWrapper(fn=kwargs_fn, base=1.0, inner=inner)
+        outer.set_params(inner__alpha=99.0)
+        assert inner._params["alpha"] == 99.0
+
+    def test_set_nested_invalid_base_key_raises(self):
+        wrapper = SimpleFunctionWrapper(fn=simple_fn)
+        with pytest.raises(ValueError, match="Invalid parameter"):
+            wrapper.set_params(nonexistent__sub=1.0)
+
+    def test_set_nested_no_set_params_raises(self):
+        wrapper = SimpleFunctionWrapper(fn=kwargs_fn, base=1.0, obj="plain_string")
+        with pytest.raises(AttributeError, match="does not have a set_params"):
+            wrapper.set_params(obj__sub=1.0)
+
+    def test_set_params_double_underscore_rejects(self):
+        # Double-underscore in set_params is treated as nested param syntax,
+        # so it raises because the base key doesn't exist in _params
+        wrapper = SimpleFunctionWrapper(fn=simple_fn)
+        with pytest.raises(ValueError, match="Invalid parameter"):
+            wrapper.set_params(bad__param=1.0)
+
+
+class TestCloneRoundtrip:
+    """Tests for sklearn.base.clone compatibility."""
+
+    def test_clone_preserves_params(self):
+        wrapper = SimpleFunctionWrapper(fn=simple_fn, alpha=5.0, beta=10.0)
+        cloned = clone(wrapper)
+        assert cloned.callable_fn is simple_fn
+        assert cloned._params["alpha"] == 5.0
+        assert cloned._params["beta"] == 10.0
+
+    def test_clone_preserves_callable_identity(self):
+        wrapper = SimpleFunctionWrapper(fn=predict_fn, scale=2.0)
+        cloned = clone(wrapper)
+        assert cloned.callable_fn is predict_fn
+
+    def test_clone_default_callable(self):
+        wrapper = DefaultCallableWrapper(alpha=3.0)
+        cloned = clone(wrapper)
+        assert cloned.callable_fn is simple_fn
+        assert cloned._params["alpha"] == 3.0
+
+    def test_clone_is_independent(self):
+        wrapper = SimpleFunctionWrapper(fn=simple_fn, alpha=1.0)
+        cloned = clone(wrapper)
+        cloned.set_params(alpha=99.0)
+        assert wrapper._params["alpha"] == 1.0
+        assert cloned._params["alpha"] == 99.0
+
+    def test_clone_not_fitted(self):
+        wrapper = SimpleFunctionWrapper(fn=simple_fn)
+        wrapper._fitted = True
+        cloned = clone(wrapper)
+        assert not cloned.__sklearn_is_fitted__()
+
+    def test_clone_lambda(self):
+        fn = lambda X, *, k=1: X * k  # noqa: E731
+        wrapper = SimpleFunctionWrapper(fn=fn, k=5)
+        cloned = clone(wrapper)
+        assert cloned.callable_fn is fn
+        assert cloned._params["k"] == 5
+
+    def test_clone_partial(self):
+        base_fn = lambda X, y, *, alpha=1.0, beta=2.0: X * alpha + beta  # noqa: E731
+        partial_fn = functools.partial(base_fn, beta=10.0)
+        wrapper = SimpleFunctionWrapper(fn=partial_fn, alpha=3.0)
+        cloned = clone(wrapper)
+        # sklearn's clone deep-copies non-estimator values, so partial identity
+        # is not preserved, but behavior and params should match
+        assert cloned._params["alpha"] == 3.0
+        assert cloned._params["beta"] == 10.0
+        assert cloned(5, 0) == wrapper(5, 0)
+
+
+class TestRepr:
+    """Tests that repr works without errors (no RecursionError)."""
+
+    def test_repr_simple(self):
+        wrapper = SimpleFunctionWrapper(fn=simple_fn, alpha=5.0)
+        r = repr(wrapper)
+        assert "SimpleFunctionWrapper" in r
+        assert "alpha=5.0" in r
+
+    def test_repr_default_callable(self):
+        wrapper = DefaultCallableWrapper()
+        r = repr(wrapper)
+        assert "DefaultCallableWrapper" in r
+
+    def test_repr_lambda(self):
+        fn = lambda X, *, k=1: X * k  # noqa: E731
+        wrapper = SimpleFunctionWrapper(fn=fn, k=3)
+        r = repr(wrapper)
+        assert "SimpleFunctionWrapper" in r

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from sklearn_wrap._validation import validate_class_params, validate_dotted_path
+from sklearn_wrap._validation import validate_class_params, validate_dotted_path, validate_function_params
 
 
 class TestValidateDottedPath:
@@ -111,3 +111,16 @@ class TestValidateClassParams:
 
         result = validate_class_params(Foo, {})
         assert result == {"x": 10, "y": 20}
+
+
+class TestValidateFunctionParams:
+    """Tests for the validate_function_params utility."""
+
+    def test_uninspectable_callable_raises(self):
+        class BadCallable:
+            def __call__(self): ...
+
+            __signature__ = property(lambda self: (_ for _ in ()).throw(ValueError("no sig")))
+
+        with pytest.raises(TypeError, match="Cannot inspect signature"):
+            validate_function_params(BadCallable(), {})


### PR DESCRIPTION
## Description

Add `FunctionWrapper`, a sibling to `BaseClassWrapper` that wraps any Python callable into an sklearn-compatible functor with `get_params`/`set_params`. Config params are identified via the keyword-only convention (after `*`), positional params are data passed at call time via `__call__`.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Motivation and Context

Users need to wrap standalone functions (not just classes) into sklearn-compatible objects for use with `GridSearchCV`, `Pipeline`, and `cross_val_score`. `FunctionWrapper` fills this gap alongside the existing `BaseClassWrapper`.

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just fix` to format my code
- [x] I have run `just lint` to verify linting and type annotations
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings

## Additional Notes

- `validate_function_params()` added to `_validation.py` (extracts keyword-only params from callable signatures)
- 47 new tests across 3 files (core, params, integration)
- Marimo example notebook at `examples/function_wrapper.py`
- Diátaxis docs: tutorial, how-to guide, and explanation page
- `_callable_default` accessed via `type(self)` to avoid descriptor binding causing repr recursion